### PR TITLE
fix(greeting): 明确 LLM 与模板的发送顺序

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 const CONFIG_FILE_NAME: &str = "app_config.yaml";
-pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+pub const CURRENT_SCHEMA_VERSION: u32 = 2;
 
 const DEFAULT_CONFIG_YAML: &str = include_str!("resource/app_config.yaml");
 
@@ -240,6 +240,10 @@ pub(crate) fn parse_config_content(content: &str) -> Result<AppRuntimeConfig, St
         {
             config.greet_config.enable_llm = true;
         }
+
+        if config.schema_version < 2 {
+            migrate_greet_send_sequence(&mut config.greet_config);
+        }
     }
     if let Some(replay_config) = value.get("replay_config") {
         config.replay_config =
@@ -340,6 +344,7 @@ pub fn validate_and_normalize(config: &mut AppRuntimeConfig) -> Result<(), Strin
 
     normalize_llm_retry_config(&mut config.llm_retry_config);
     normalize_llm_fallbacks(&mut config.llm_fallbacks)?;
+    validate_greet_template(&config.greet_config)?;
 
     let Some(llm_config) = config.llm_config.as_mut() else {
         return Ok(());
@@ -352,6 +357,45 @@ pub fn validate_and_normalize(config: &mut AppRuntimeConfig) -> Result<(), Strin
     }
     if llm_config.model.is_empty() {
         return Err("模型名称不能为空".to_string());
+    }
+    Ok(())
+}
+
+/// v1 在模板缺少 LLM 条目时会在运行期把生成内容隐式插到第一条。
+/// v2 改为完全显式的发送序列，因此升级时只需补出这个条目；运行期不再保留兼容分支。
+fn migrate_greet_send_sequence(greet: &mut GreetConfig) {
+    let mut found_llm = false;
+    greet.default_template.retain(|resource| {
+        if resource.resource_type != ReplayResourceType::LLM {
+            return true;
+        }
+        if found_llm {
+            return false;
+        }
+        found_llm = true;
+        true
+    });
+
+    let prompt_ready = greet
+        .reply_prompt
+        .as_deref()
+        .is_some_and(|prompt| !prompt.trim().is_empty());
+    if greet.enable_llm && prompt_ready && !found_llm {
+        greet.default_template.insert(
+            0,
+            GreetResource::new(ReplayResourceType::LLM, String::new()),
+        );
+    }
+}
+
+fn validate_greet_template(greet: &GreetConfig) -> Result<(), String> {
+    let llm_count = greet
+        .default_template
+        .iter()
+        .filter(|resource| resource.resource_type == ReplayResourceType::LLM)
+        .count();
+    if llm_count > 1 {
+        return Err("打招呼发送序列最多只能包含一条 LLM 内容".to_string());
     }
     Ok(())
 }
@@ -634,15 +678,18 @@ impl AppRuntimeConfig {
             model: primary.model.clone(),
         });
 
-        chain.extend(self.llm_fallbacks.iter().filter(|entry| entry.enabled).map(
-            |entry| LlmChainLink {
-                id: entry.id.clone(),
-                label: entry.label.clone(),
-                provider: entry.provider.clone(),
-                base_url: entry.base_url.clone(),
-                model: entry.model.clone(),
-            },
-        ));
+        chain.extend(
+            self.llm_fallbacks
+                .iter()
+                .filter(|entry| entry.enabled)
+                .map(|entry| LlmChainLink {
+                    id: entry.id.clone(),
+                    label: entry.label.clone(),
+                    provider: entry.provider.clone(),
+                    base_url: entry.base_url.clone(),
+                    model: entry.model.clone(),
+                }),
+        );
 
         chain
     }
@@ -815,7 +862,35 @@ pub struct GreetConfig {
     pub reply_prompt: Option<String>,
 
     // 默认模板
-    pub default_template: Vec<ReplyResource>,
+    pub default_template: Vec<GreetResource>,
+}
+
+impl GreetConfig {
+    pub fn prompt_ready(&self) -> bool {
+        self.reply_prompt
+            .as_deref()
+            .is_some_and(|prompt| !prompt.trim().is_empty())
+    }
+
+    pub fn has_enabled_llm_resource(&self) -> bool {
+        self.default_template
+            .iter()
+            .any(|resource| resource.enabled && resource.resource_type == ReplayResourceType::LLM)
+    }
+
+    pub fn llm_resource_ready(&self) -> bool {
+        self.enable_llm && self.prompt_ready() && self.has_enabled_llm_resource()
+    }
+
+    pub fn has_sendable_resource(&self) -> bool {
+        self.default_template.iter().any(|resource| {
+            resource.enabled
+                && match resource.resource_type {
+                    ReplayResourceType::LLM => self.llm_resource_ready(),
+                    _ => !resource.content.trim().is_empty(),
+                }
+        })
+    }
 }
 
 // ================================
@@ -858,6 +933,32 @@ pub struct ReplyRegexRule {
 
     /// 匹配目标 最近的limit条聊天记录
     pub limit: i32,
+}
+
+// 打招呼发送资源
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct GreetResource {
+    /// 是否参与发送。旧配置缺少此字段时默认启用；启用状态不落盘，保持配置简洁。
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    pub enabled: bool,
+    /// 回复类型
+    pub resource_type: ReplayResourceType,
+    /// 回复内容 图片 则传 图片路径
+    pub content: String,
+}
+
+impl GreetResource {
+    pub fn new(resource_type: ReplayResourceType, content: String) -> Self {
+        Self {
+            enabled: true,
+            resource_type,
+            content,
+        }
+    }
+}
+
+fn is_true(value: &bool) -> bool {
+    *value
 }
 
 // 回复资源
@@ -922,10 +1023,10 @@ mod tests {
     }
 
     #[test]
-    fn default_config_is_version_one_and_ai_unconfigured() {
+    fn default_config_uses_current_version_and_ai_is_unconfigured() {
         let config = default_app_config();
 
-        assert_eq!(config.schema_version, 1);
+        assert_eq!(config.schema_version, CURRENT_SCHEMA_VERSION);
         assert!(!config.onboarding_completed);
         assert!(config.llm_config.is_none());
     }
@@ -964,7 +1065,11 @@ mod tests {
 
     #[test]
     fn future_schema_versions_are_rejected_instead_of_downgraded() {
-        let error = parse_config_content("schema_version: 2\nllm_config: null\n").unwrap_err();
+        let error = parse_config_content(&format!(
+            "schema_version: {}\nllm_config: null\n",
+            CURRENT_SCHEMA_VERSION + 1
+        ))
+        .unwrap_err();
 
         assert!(error.contains("版本"));
     }
@@ -1172,6 +1277,11 @@ greet_config:
         .unwrap();
 
         assert!(config.greet_config.enable_llm);
+        assert_eq!(config.greet_config.default_template.len(), 1);
+        assert_eq!(
+            config.greet_config.default_template[0].resource_type,
+            ReplayResourceType::LLM
+        );
     }
 
     #[test]
@@ -1221,6 +1331,73 @@ greet_config:
 
         let restored: GreetConfig = serde_yaml::from_str(&serialized).unwrap();
         assert!(restored.enable_llm);
+    }
+
+    #[test]
+    fn legacy_resource_without_enabled_field_defaults_to_enabled() {
+        let resource: GreetResource = serde_yaml::from_str(
+            r#"
+resource_type: Text
+content: "您好"
+"#,
+        )
+        .unwrap();
+
+        assert!(resource.enabled);
+        let serialized = serde_yaml::to_string(&resource).unwrap();
+        assert!(!serialized.contains("enabled:"));
+    }
+
+    #[test]
+    fn disabled_resource_is_serialized_explicitly() {
+        let resource = GreetResource {
+            enabled: false,
+            resource_type: ReplayResourceType::Text,
+            content: "保留但不发送".to_string(),
+        };
+
+        let serialized = serde_yaml::to_string(&resource).unwrap();
+
+        assert!(serialized.contains("enabled: false"));
+    }
+
+    #[test]
+    fn v1_greet_without_llm_slot_is_migrated_once_to_an_explicit_first_item() {
+        let config = parse_config_content(
+            r#"
+schema_version: 1
+greet_config:
+  enable_llm: true
+  reply_prompt: "生成内容"
+  default_template:
+    - resource_type: Text
+      content: "固定内容"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.greet_config.default_template.len(), 2);
+        assert_eq!(
+            config.greet_config.default_template[0].resource_type,
+            ReplayResourceType::LLM
+        );
+        assert_eq!(config.greet_config.default_template[1].content, "固定内容");
+
+        let serialized = serde_yaml::to_string(&config).unwrap();
+        let restored = parse_config_content(&serialized).unwrap();
+        assert_eq!(restored.greet_config.default_template.len(), 2);
+    }
+
+    #[test]
+    fn multiple_llm_items_are_rejected() {
+        let mut config = default_app_config();
+        config.greet_config.default_template = vec![
+            GreetResource::new(ReplayResourceType::LLM, String::new()),
+            GreetResource::new(ReplayResourceType::LLM, String::new()),
+        ];
+
+        let error = validate_and_normalize(&mut config).unwrap_err();
+        assert!(error.contains("最多只能包含一条 LLM"));
     }
 
     fn fallback_entry(id: &str, model: &str) -> LlmProviderEntry {
@@ -1306,11 +1483,17 @@ greet_config:
             config.llm_retry_config.network_retry_attempts,
             MAX_NETWORK_RETRY_ATTEMPTS
         );
-        assert_eq!(config.llm_retry_config.retry_base_delay_ms, MIN_RETRY_BASE_DELAY_MS);
+        assert_eq!(
+            config.llm_retry_config.retry_base_delay_ms,
+            MIN_RETRY_BASE_DELAY_MS
+        );
 
         config.llm_retry_config.retry_base_delay_ms = 999_999;
         validate_and_normalize(&mut config).unwrap();
-        assert_eq!(config.llm_retry_config.retry_base_delay_ms, MAX_RETRY_BASE_DELAY_MS);
+        assert_eq!(
+            config.llm_retry_config.retry_base_delay_ms,
+            MAX_RETRY_BASE_DELAY_MS
+        );
     }
 
     #[test]
@@ -1362,7 +1545,10 @@ greet_config:
 
         validate_and_normalize(&mut config).unwrap();
 
-        assert_eq!(config.llm_fallbacks[0].base_url, "https://llm.example.test/v1");
+        assert_eq!(
+            config.llm_fallbacks[0].base_url,
+            "https://llm.example.test/v1"
+        );
         assert_eq!(config.llm_fallbacks[0].model, "qwen-max");
         assert_eq!(config.llm_fallbacks[0].label, None);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ pub fn run() {
             let handle = app.handle().clone();
             let data_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
             let config_path = config::config_path(&handle).map_err(|e| e.to_string())?;
-            storage::migration::migrate_v0_to_v1(
+            storage::migration::migrate_to_current(
                 &storage::migration::MigrationPaths::new(config_path, data_dir.clone()),
                 &credential::KeyringCredentialBackend::default(),
             )

--- a/src-tauri/src/resource/app_config.yaml
+++ b/src-tauri/src/resource/app_config.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 onboarding_completed: false
 llm_config: null
 job_filter_config:

--- a/src-tauri/src/rpa/boss/handler/position_say_hello.rs
+++ b/src-tauri/src/rpa/boss/handler/position_say_hello.rs
@@ -3,14 +3,12 @@ use std::time::Duration;
 
 use crate::{
     browser,
-    config::{
-        AppRuntimeConfig, GreetConfig, JobFilterConfig, ReplayResourceType, ReplyResource,
-    },
+    config::{AppRuntimeConfig, JobFilterConfig, ReplyResource},
     dao::{job_detail_dao, model::JobDetail},
-    llm::generate_greet_text,
     logger,
     rpa::{
         boss::{handler::send_messages, model::GreetJob},
+        greet::build_greet_resources,
         run_flow::is_job_task_stop_requested,
         run_flow::PlatformKind,
     },
@@ -1005,94 +1003,6 @@ where
     send(resources)
 }
 
-/// 是否需要真的调用大模型：既要开关打开，也要有非空提示词。
-/// 否则调用模型只是白白消耗 token 和时间。
-fn should_use_llm(greet: &GreetConfig) -> bool {
-    greet.enable_llm
-        && greet
-            .reply_prompt
-            .as_deref()
-            .is_some_and(|prompt| !prompt.trim().is_empty())
-}
-
-/// 模板中是否存在 LLM 占位条目
-fn has_llm_slot(resources: &[ReplyResource]) -> bool {
-    resources
-        .iter()
-        .any(|resource| resource.resource_type == ReplayResourceType::LLM)
-}
-
-/// 根据模板列表与模型生成结果产出最终要发送的资源列表。
-/// - 有生成内容且模板里没有 LLM 条目：把生成内容插到最前面，不再白白丢弃
-/// - 有生成内容且模板里有 LLM 条目：替换所有 LLM 条目的内容
-/// - 没有生成内容：丢弃 LLM 空壳条目，只发送显式模板
-fn compose_greet_resources(
-    resources: Vec<ReplyResource>,
-    generated: Option<String>,
-) -> Vec<ReplyResource> {
-    let mut resources = match generated {
-        Some(text) => {
-            if has_llm_slot(&resources) {
-                resources
-                    .into_iter()
-                    .map(|mut resource| {
-                        if resource.resource_type == ReplayResourceType::LLM {
-                            resource.content = text.clone();
-                        }
-                        resource
-                    })
-                    .collect()
-            } else {
-                let mut merged = Vec::with_capacity(resources.len() + 1);
-                merged.push(ReplyResource {
-                    resource_type: ReplayResourceType::LLM,
-                    content: text,
-                });
-                merged.extend(resources);
-                merged
-            }
-        }
-        None => resources
-            .into_iter()
-            .filter(|resource| resource.resource_type != ReplayResourceType::LLM)
-            .collect(),
-    };
-
-    resources.retain(|resource| !resource.content.trim().is_empty());
-    resources
-}
-
-async fn build_greet_resources(
-    config: &AppRuntimeConfig,
-    greet_job: &GreetJob,
-) -> Result<Vec<ReplyResource>, anyhow::Error> {
-    let greet = &config.greet_config;
-    let resources = greet.default_template.clone();
-
-    // 未启用 LLM 或没有可用提示词：不调用模型，同时丢弃 LLM 类型的空壳条目
-    if !should_use_llm(greet) {
-        return Ok(compose_greet_resources(resources, None));
-    }
-
-    let generated = match generate_greet_text(config.clone(), greet_job).await {
-        Ok(result) if result.success && !result.data.trim().is_empty() => Some(result.data),
-        Ok(_) => {
-            logger::warning("LLM 未生成打招呼内容，仅发送显式模板")?;
-            None
-        }
-        Err(error) => {
-            logger::warning(format!("LLM 打招呼生成失败，仅发送显式模板: {}", error))?;
-            None
-        }
-    };
-
-    if generated.is_some() && !has_llm_slot(&resources) {
-        logger::info("打招呼模板未配置 LLM 条目，已将模型生成内容作为首条发送")?;
-    }
-
-    Ok(compose_greet_resources(resources, generated))
-}
-
 /// 一次滚动前后的页面高度，作为“是否加载了新内容”的辅助信号
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct ScrollProbe {
@@ -1385,7 +1295,8 @@ mod tests {
     fn scroll_script_moves_up_before_returning_to_the_bottom() {
         // 已经在底部时必须先产生反向位移，否则懒加载观察器不会被唤醒
         assert!(SCROLL_NUDGE_UP_SCRIPT.contains("scrollContainer.scrollTop - 520"));
-        assert!(SCROLL_BOTTOM_SCRIPT.contains("scrollContainer.scrollTop = scrollContainer.scrollHeight"));
+        assert!(SCROLL_BOTTOM_SCRIPT
+            .contains("scrollContainer.scrollTop = scrollContainer.scrollHeight"));
         assert!(SCROLL_NUDGE_UP_SCRIPT.contains("scrollHeight"));
         assert!(SCROLL_HEIGHT_SCRIPT.contains("scrollHeight"));
     }
@@ -1490,109 +1401,6 @@ mod tests {
             assert!(text.contains("正常结束、不是程序崩溃"), "{text}");
             assert!(text.contains("周期投递"), "{text}");
         }
-    }
-
-    fn text_resource(content: &str) -> ReplyResource {
-        ReplyResource {
-            resource_type: ReplayResourceType::Text,
-            content: content.to_string(),
-        }
-    }
-
-    fn llm_resource(content: &str) -> ReplyResource {
-        ReplyResource {
-            resource_type: ReplayResourceType::LLM,
-            content: content.to_string(),
-        }
-    }
-
-    fn greet_config(enable_llm: bool, reply_prompt: Option<&str>) -> GreetConfig {
-        GreetConfig {
-            enable_llm,
-            reply_prompt: reply_prompt.map(|prompt| prompt.to_string()),
-            default_template: Vec::new(),
-        }
-    }
-
-    #[test]
-    fn llm_is_only_called_when_enabled_with_a_non_blank_prompt() {
-        assert!(should_use_llm(&greet_config(true, Some("请生成招呼语"))));
-        assert!(!should_use_llm(&greet_config(false, Some("请生成招呼语"))));
-        assert!(!should_use_llm(&greet_config(true, None)));
-        assert!(!should_use_llm(&greet_config(true, Some("   "))));
-    }
-
-    #[test]
-    fn generated_text_is_prepended_when_the_template_has_no_llm_slot() {
-        let resources = compose_greet_resources(
-            vec![text_resource("您好，我对该岗位很感兴趣")],
-            Some("您好，我有五年 Rust 经验".to_string()),
-        );
-
-        assert_eq!(resources.len(), 2);
-        assert_eq!(resources[0].resource_type, ReplayResourceType::LLM);
-        assert_eq!(resources[0].content, "您好，我有五年 Rust 经验");
-        assert_eq!(resources[1].content, "您好，我对该岗位很感兴趣");
-    }
-
-    #[test]
-    fn generated_text_replaces_every_existing_llm_slot() {
-        let resources = compose_greet_resources(
-            vec![
-                text_resource("固定开场白"),
-                llm_resource(""),
-                llm_resource("占位"),
-            ],
-            Some("模型生成内容".to_string()),
-        );
-
-        assert_eq!(resources.len(), 3);
-        assert_eq!(resources[0].content, "固定开场白");
-        assert_eq!(resources[1].content, "模型生成内容");
-        assert_eq!(resources[2].content, "模型生成内容");
-    }
-
-    #[test]
-    fn llm_slots_are_dropped_when_generation_fails() {
-        let resources = compose_greet_resources(
-            vec![llm_resource("占位"), text_resource("固定开场白")],
-            None,
-        );
-
-        assert_eq!(resources.len(), 1);
-        assert_eq!(resources[0].resource_type, ReplayResourceType::Text);
-        assert_eq!(resources[0].content, "固定开场白");
-    }
-
-    #[test]
-    fn llm_slots_are_dropped_when_llm_is_disabled() {
-        // 未启用 LLM 时上层传入 None，等价于直接丢弃 LLM 空壳条目
-        let greet = greet_config(false, Some("请生成招呼语"));
-        assert!(!should_use_llm(&greet));
-
-        let resources =
-            compose_greet_resources(vec![llm_resource(""), text_resource("固定开场白")], None);
-
-        assert_eq!(resources.len(), 1);
-        assert_eq!(resources[0].content, "固定开场白");
-    }
-
-    #[test]
-    fn blank_resources_are_filtered_out() {
-        let resources = compose_greet_resources(
-            vec![
-                text_resource("   "),
-                text_resource(""),
-                text_resource("有效内容"),
-            ],
-            None,
-        );
-
-        assert_eq!(resources.len(), 1);
-        assert_eq!(resources[0].content, "有效内容");
-
-        // 模型返回空白时同样不会被塞进发送列表
-        assert!(compose_greet_resources(Vec::new(), Some("  \n ".to_string())).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/rpa/greet.rs
+++ b/src-tauri/src/rpa/greet.rs
@@ -1,0 +1,134 @@
+use crate::{
+    config::{AppRuntimeConfig, GreetConfig, GreetResource, ReplayResourceType, ReplyResource},
+    llm::generate_greet_text,
+    logger,
+    rpa::common::RpaJob,
+};
+
+/// 把配置的显式发送序列转换为最终资源列表。
+/// 禁用项和空内容不会发送；LLM 生成不可用时仅跳过 LLM 项，不影响后续固定内容。
+fn compose_greet_resources(greet: &GreetConfig, generated: Option<String>) -> Vec<ReplyResource> {
+    let generated = generated.filter(|text| !text.trim().is_empty());
+
+    greet
+        .default_template
+        .iter()
+        .filter(|resource| resource.enabled)
+        .filter_map(|resource| {
+            let content = if resource.resource_type == ReplayResourceType::LLM {
+                generated.clone()?
+            } else {
+                resource.content.clone()
+            };
+            (!content.trim().is_empty()).then_some(ReplyResource {
+                resource_type: resource.resource_type.clone(),
+                content,
+            })
+        })
+        .collect()
+}
+
+pub async fn build_greet_resources(
+    config: &AppRuntimeConfig,
+    job: &RpaJob,
+) -> Result<Vec<ReplyResource>, anyhow::Error> {
+    let generated = if config.greet_config.llm_resource_ready() {
+        match generate_greet_text(config.clone(), job).await {
+            Ok(result) if result.success && !result.data.trim().is_empty() => Some(result.data),
+            Ok(_) => {
+                logger::warning("LLM 未生成打招呼内容，已跳过该条")?;
+                None
+            }
+            Err(error) => {
+                logger::warning(format!("LLM 打招呼生成失败，已跳过该条: {}", error))?;
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let resources = compose_greet_resources(&config.greet_config, generated);
+    if resources.is_empty() {
+        return Err(anyhow::anyhow!(
+            "打招呼发送序列没有可发送内容，请至少启用并配置一条有效内容"
+        ));
+    }
+    Ok(resources)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resource(resource_type: ReplayResourceType, content: &str, enabled: bool) -> GreetResource {
+        GreetResource {
+            enabled,
+            resource_type,
+            content: content.to_string(),
+        }
+    }
+
+    fn greet(resources: Vec<GreetResource>) -> GreetConfig {
+        GreetConfig {
+            enable_llm: true,
+            reply_prompt: Some("生成打招呼内容".to_string()),
+            default_template: resources,
+        }
+    }
+
+    #[test]
+    fn explicit_sequence_keeps_enabled_items_in_order() {
+        let greet = greet(vec![
+            resource(ReplayResourceType::Text, "第一条", true),
+            resource(ReplayResourceType::LLM, "", true),
+            resource(ReplayResourceType::Text, "第三条", true),
+        ]);
+
+        let resources = compose_greet_resources(&greet, Some("模型内容".to_string()));
+
+        assert_eq!(resources.len(), 3);
+        assert_eq!(resources[0].content, "第一条");
+        assert_eq!(resources[1].content, "模型内容");
+        assert_eq!(resources[2].content, "第三条");
+    }
+
+    #[test]
+    fn disabled_and_blank_items_are_not_sent() {
+        let greet = greet(vec![
+            resource(ReplayResourceType::Text, "停用内容", false),
+            resource(ReplayResourceType::LLM, "", false),
+            resource(ReplayResourceType::Text, "   ", true),
+            resource(ReplayResourceType::Text, "有效内容", true),
+        ]);
+
+        assert!(!greet.llm_resource_ready());
+        assert_eq!(compose_greet_resources(&greet, None).len(), 1);
+        assert_eq!(compose_greet_resources(&greet, None)[0].content, "有效内容");
+    }
+
+    #[test]
+    fn llm_failure_skips_only_llm_item() {
+        let greet = greet(vec![
+            resource(ReplayResourceType::Text, "开场", true),
+            resource(ReplayResourceType::LLM, "", true),
+            resource(ReplayResourceType::Text, "兜底", true),
+        ]);
+
+        let resources = compose_greet_resources(&greet, None);
+
+        assert_eq!(resources.len(), 2);
+        assert_eq!(resources[0].content, "开场");
+        assert_eq!(resources[1].content, "兜底");
+    }
+
+    #[test]
+    fn llm_is_not_implicitly_inserted_without_a_slot() {
+        let greet = greet(vec![resource(ReplayResourceType::Text, "固定内容", true)]);
+
+        assert!(!greet.llm_resource_ready());
+        let resources = compose_greet_resources(&greet, Some("不应发送".to_string()));
+        assert_eq!(resources.len(), 1);
+        assert_eq!(resources[0].content, "固定内容");
+    }
+}

--- a/src-tauri/src/rpa/liepin/handler/position_say_hello.rs
+++ b/src-tauri/src/rpa/liepin/handler/position_say_hello.rs
@@ -3,11 +3,13 @@ use std::time::Duration;
 
 use crate::{
     browser,
-    config::{AppRuntimeConfig, GreetConfig, ReplayResourceType, ReplyResource},
+    config::{AppRuntimeConfig, ReplayResourceType, ReplyResource},
     dao::{job_detail_dao, model::JobDetail},
-    llm::generate_greet_text,
     logger,
-    rpa::{common::RpaJob, liepin::LIEPIN_SITE_URL, run_flow::is_job_task_stop_requested},
+    rpa::{
+        common::RpaJob, greet::build_greet_resources, liepin::LIEPIN_SITE_URL,
+        run_flow::is_job_task_stop_requested,
+    },
     utils::salary::decode_salary,
     verify,
 };
@@ -542,91 +544,6 @@ fn greet_failure_message(title: &str, company_name: &str, error: &anyhow::Error)
     )
 }
 
-async fn build_greet_resources(
-    config: &AppRuntimeConfig,
-    job: &RpaJob,
-) -> Result<Vec<ReplyResource>, anyhow::Error> {
-    let greet = &config.greet_config;
-    let resources = greet.default_template.clone();
-
-    // 未启用 LLM 打招呼或提示词为空时不调用模型，同时丢弃模板里的 LLM 空壳条目
-    if !should_use_llm(greet) {
-        return Ok(compose_greet_resources(resources, None));
-    }
-
-    let generated = match generate_greet_text(config.clone(), job).await {
-        Ok(result) if result.success && !result.data.trim().is_empty() => Some(result.data),
-        Ok(_) => {
-            logger::warning("LLM 未生成打招呼内容，仅发送显式模板")?;
-            None
-        }
-        Err(error) => {
-            logger::warning(format!("LLM 打招呼生成失败，仅发送显式模板: {}", error))?;
-            None
-        }
-    };
-
-    if generated.is_some() && !has_llm_resource(&resources) {
-        logger::info("打招呼模板未配置 LLM 条目，已将模型生成内容作为首条发送")?;
-    }
-
-    Ok(compose_greet_resources(resources, generated))
-}
-
-/// 只有同时打开开关并填写了提示词，才真正调用大模型
-fn should_use_llm(greet: &GreetConfig) -> bool {
-    greet.enable_llm
-        && greet
-            .reply_prompt
-            .as_deref()
-            .is_some_and(|prompt| !prompt.trim().is_empty())
-}
-
-fn has_llm_resource(resources: &[ReplyResource]) -> bool {
-    resources
-        .iter()
-        .any(|resource| resource.resource_type == ReplayResourceType::LLM)
-}
-
-/// 根据模型生成结果拼装最终要发送的资源列表：
-/// - 有生成内容且模板里没有 LLM 条目：插到首位发送
-/// - 有生成内容且模板里有 LLM 条目：替换所有 LLM 条目的内容
-/// - 没有生成内容：丢弃全部 LLM 条目，仅发送显式模板
-fn compose_greet_resources(
-    resources: Vec<ReplyResource>,
-    generated: Option<String>,
-) -> Vec<ReplyResource> {
-    let mut composed: Vec<ReplyResource> = match generated {
-        Some(text) => {
-            if has_llm_resource(&resources) {
-                resources
-                    .into_iter()
-                    .map(|mut resource| {
-                        if resource.resource_type == ReplayResourceType::LLM {
-                            resource.content = text.clone();
-                        }
-                        resource
-                    })
-                    .collect()
-            } else {
-                let mut merged = vec![ReplyResource {
-                    resource_type: ReplayResourceType::LLM,
-                    content: text,
-                }];
-                merged.extend(resources);
-                merged
-            }
-        }
-        None => resources
-            .into_iter()
-            .filter(|resource| resource.resource_type != ReplayResourceType::LLM)
-            .collect(),
-    };
-
-    composed.retain(|resource| !resource.content.trim().is_empty());
-    composed
-}
-
 pub(crate) fn send_resources(
     page: &Page,
     resources: Vec<ReplyResource>,
@@ -1101,94 +1018,5 @@ mod tests {
         assert!(message.contains("皓元医药"));
         assert!(message.contains("发送失败"));
         assert!(message.contains("跳过该岗位，继续处理下一个"));
-    }
-
-    fn text_resource(content: &str) -> ReplyResource {
-        ReplyResource {
-            resource_type: ReplayResourceType::Text,
-            content: content.to_string(),
-        }
-    }
-
-    fn llm_resource(content: &str) -> ReplyResource {
-        ReplyResource {
-            resource_type: ReplayResourceType::LLM,
-            content: content.to_string(),
-        }
-    }
-
-    fn greet_config(enable_llm: bool, prompt: Option<&str>) -> GreetConfig {
-        GreetConfig {
-            enable_llm,
-            reply_prompt: prompt.map(|value| value.to_string()),
-            default_template: Vec::new(),
-        }
-    }
-
-    #[test]
-    fn should_use_llm_requires_switch_and_non_empty_prompt() {
-        assert!(should_use_llm(&greet_config(true, Some("生成打招呼内容"))));
-        assert!(!should_use_llm(&greet_config(false, Some("生成打招呼内容"))));
-        assert!(!should_use_llm(&greet_config(true, None)));
-        assert!(!should_use_llm(&greet_config(true, Some("   "))));
-    }
-
-    #[test]
-    fn generated_text_is_prepended_when_template_has_no_llm_resource() {
-        let resources = compose_greet_resources(
-            vec![text_resource("您好，期待沟通")],
-            Some("模型生成的开场白".to_string()),
-        );
-
-        assert_eq!(resources.len(), 2);
-        assert_eq!(resources[0].resource_type, ReplayResourceType::LLM);
-        assert_eq!(resources[0].content, "模型生成的开场白");
-        assert_eq!(resources[1].content, "您好，期待沟通");
-    }
-
-    #[test]
-    fn generated_text_replaces_existing_llm_resources_in_place() {
-        let resources = compose_greet_resources(
-            vec![
-                text_resource("您好"),
-                llm_resource(""),
-                text_resource("期待回复"),
-            ],
-            Some("模型生成的开场白".to_string()),
-        );
-
-        assert_eq!(resources.len(), 3);
-        assert_eq!(resources[0].content, "您好");
-        assert_eq!(resources[1].resource_type, ReplayResourceType::LLM);
-        assert_eq!(resources[1].content, "模型生成的开场白");
-        assert_eq!(resources[2].content, "期待回复");
-    }
-
-    #[test]
-    fn llm_resources_are_dropped_when_generation_is_unavailable() {
-        let resources = compose_greet_resources(
-            vec![
-                llm_resource(""),
-                text_resource("您好，期待沟通"),
-                llm_resource("残留内容"),
-            ],
-            None,
-        );
-
-        assert_eq!(resources.len(), 1);
-        assert_eq!(resources[0].resource_type, ReplayResourceType::Text);
-        assert_eq!(resources[0].content, "您好，期待沟通");
-    }
-
-    #[test]
-    fn empty_resources_are_filtered_out() {
-        let resources = compose_greet_resources(
-            vec![text_resource("   "), text_resource("您好")],
-            Some("模型生成的开场白".to_string()),
-        );
-
-        assert_eq!(resources.len(), 2);
-        assert_eq!(resources[0].content, "模型生成的开场白");
-        assert_eq!(resources[1].content, "您好");
     }
 }

--- a/src-tauri/src/rpa/mod.rs
+++ b/src-tauri/src/rpa/mod.rs
@@ -1,4 +1,5 @@
 pub mod boss;
 pub mod common;
+pub mod greet;
 pub mod liepin;
 pub mod run_flow;

--- a/src-tauri/src/rpa/run_flow.rs
+++ b/src-tauri/src/rpa/run_flow.rs
@@ -185,20 +185,10 @@ pub fn inspect_readiness(
         config_group: Some("resume".to_string()),
     });
 
-    let greet_prompt_ready = config
-        .greet_config
-        .reply_prompt
-        .as_deref()
-        .is_some_and(|value| !value.trim().is_empty());
-    // 打开了 LLM 打招呼却没填提示词，模型不会被调用，属于配置不完整
-    let greet_prompt_missing = config.greet_config.enable_llm && !greet_prompt_ready;
-    let greet_ready = !greet_prompt_missing
-        && (config
-            .greet_config
-            .default_template
-            .iter()
-            .any(|resource| !resource.content.trim().is_empty())
-            || greet_prompt_ready);
+    let greet_prompt_missing = config.greet_config.enable_llm
+        && config.greet_config.has_enabled_llm_resource()
+        && !config.greet_config.prompt_ready();
+    let greet_ready = !greet_prompt_missing && config.greet_config.has_sendable_resource();
     items.push(ReadinessItem {
         key: "greet".to_string(),
         label: "打招呼话术".to_string(),
@@ -214,7 +204,7 @@ pub fn inspect_readiness(
         } else if greet_prompt_missing {
             "已启用 LLM 打招呼，请填写主动沟通提示词".to_string()
         } else {
-            "请至少配置一条有效打招呼资源或提示词".to_string()
+            "请至少启用并配置一条有效的打招呼内容".to_string()
         },
         config_group: Some("greet".to_string()),
     });
@@ -279,13 +269,7 @@ pub fn inspect_readiness(
     let llm_needed = !matches!(mode, FlowMode::SyncChatHistory)
         && (config.replay_config.enable_llm
             || config.job_filter_config.enable_semantic_filter
-            || (config.greet_config.enable_llm && greet_prompt_ready)
-            || config.greet_config.default_template.iter().any(|resource| {
-                matches!(
-                    resource.resource_type,
-                    crate::config::ReplayResourceType::LLM
-                )
-            }));
+            || config.greet_config.llm_resource_ready());
     items.push(ReadinessItem {
         key: "llm".to_string(),
         label: "大模型".to_string(),
@@ -532,7 +516,7 @@ async fn wait_periodic_interval(interval_minutes: u64) -> Result<(), anyhow::Err
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{default_app_config, ReplayResourceType, ReplyResource};
+    use crate::config::{default_app_config, GreetResource, ReplayResourceType};
 
     fn find_item<'a>(report: &'a ReadinessReport, key: &str) -> &'a ReadinessItem {
         report
@@ -552,9 +536,10 @@ mod tests {
         config.job_filter_config.query = Some("Rust 工程师".to_string());
         config.greet_config.enable_llm = true;
         config.greet_config.reply_prompt = Some("   ".to_string());
-        config.greet_config.default_template = vec![ReplyResource {
-            resource_type: ReplayResourceType::Text,
-            content: "您好".to_string(),
+        config.greet_config.default_template = vec![GreetResource {
+            enabled: true,
+            resource_type: ReplayResourceType::LLM,
+            content: String::new(),
         }];
 
         let report = job_hunting_report(&config);
@@ -565,7 +550,7 @@ mod tests {
     }
 
     #[test]
-    fn greet_is_ready_when_llm_enabled_with_prompt() {
+    fn greet_is_blocked_when_no_send_sequence_item_exists() {
         let mut config = default_app_config();
         config.job_filter_config.query = Some("Rust 工程师".to_string());
         config.greet_config.enable_llm = true;
@@ -574,16 +559,21 @@ mod tests {
         let report = job_hunting_report(&config);
         let greet = find_item(&report, "greet");
 
-        assert_eq!(greet.level, ReadinessLevel::Ready);
-        assert_eq!(greet.message, "打招呼资源已配置");
+        assert_eq!(greet.level, ReadinessLevel::Blocked);
+        assert_eq!(greet.message, "请至少启用并配置一条有效的打招呼内容");
     }
 
     #[test]
-    fn llm_is_required_when_greet_llm_enabled_with_prompt_but_no_llm_template() {
+    fn llm_is_required_when_enabled_llm_item_is_ready() {
         let mut config = default_app_config();
         config.job_filter_config.query = Some("Rust 工程师".to_string());
         config.greet_config.enable_llm = true;
         config.greet_config.reply_prompt = Some("请生成打招呼内容".to_string());
+        config.greet_config.default_template = vec![GreetResource {
+            enabled: true,
+            resource_type: ReplayResourceType::LLM,
+            content: String::new(),
+        }];
 
         let report = job_hunting_report(&config);
         let llm = find_item(&report, "llm");
@@ -593,12 +583,32 @@ mod tests {
     }
 
     #[test]
+    fn disabled_llm_item_does_not_require_model_service() {
+        let mut config = default_app_config();
+        config.job_filter_config.query = Some("Rust 工程师".to_string());
+        config.greet_config.enable_llm = true;
+        config.greet_config.reply_prompt = Some("请生成打招呼内容".to_string());
+        config.greet_config.default_template = vec![GreetResource {
+            enabled: false,
+            resource_type: ReplayResourceType::LLM,
+            content: String::new(),
+        }];
+
+        let report = job_hunting_report(&config);
+        let llm = find_item(&report, "llm");
+
+        assert_eq!(llm.level, ReadinessLevel::Ready);
+        assert_eq!(llm.message, "当前模式不依赖大模型");
+    }
+
+    #[test]
     fn llm_is_not_required_when_greet_llm_disabled() {
         let mut config = default_app_config();
         config.job_filter_config.query = Some("Rust 工程师".to_string());
         config.greet_config.enable_llm = false;
         config.greet_config.reply_prompt = Some("请生成打招呼内容".to_string());
-        config.greet_config.default_template = vec![ReplyResource {
+        config.greet_config.default_template = vec![GreetResource {
+            enabled: true,
             resource_type: ReplayResourceType::Text,
             content: "您好".to_string(),
         }];

--- a/src-tauri/src/storage/migration.rs
+++ b/src-tauri/src/storage/migration.rs
@@ -78,7 +78,7 @@ impl MigrationReport {
     }
 }
 
-pub fn migrate_v0_to_v1<B: CredentialBackend + ?Sized>(
+pub fn migrate_to_current<B: CredentialBackend + ?Sized>(
     paths: &MigrationPaths,
     credential_backend: &B,
 ) -> Result<MigrationReport, AppError> {
@@ -511,7 +511,7 @@ browser_config:
         let expected = resume_document(&[("old", "old content")]);
         write_json(&paths.legacy_user_resumes_path(), &expected);
 
-        let report = migrate_v0_to_v1(&paths, &FakeCredentialBackend::default()).unwrap();
+        let report = migrate_to_current(&paths, &FakeCredentialBackend::default()).unwrap();
 
         assert_eq!(report.resume_action, ResumeMigrationAction::OldCopied);
         assert_eq!(
@@ -535,7 +535,7 @@ browser_config:
         write_json(&paths.user_resumes_path(), &expected);
         let original = fs::read(paths.user_resumes_path()).unwrap();
 
-        let report = migrate_v0_to_v1(&paths, &FakeCredentialBackend::default()).unwrap();
+        let report = migrate_to_current(&paths, &FakeCredentialBackend::default()).unwrap();
 
         assert_eq!(report.resume_action, ResumeMigrationAction::TargetKept);
         assert_eq!(fs::read(paths.user_resumes_path()).unwrap(), original);
@@ -556,7 +556,7 @@ browser_config:
         )
         .unwrap();
 
-        let report = migrate_v0_to_v1(&paths, &FakeCredentialBackend::default()).unwrap();
+        let report = migrate_to_current(&paths, &FakeCredentialBackend::default()).unwrap();
 
         assert_eq!(
             report.resume_action,
@@ -580,7 +580,7 @@ browser_config:
             &resume_document(&[("shared", "target"), ("target-only", "target-only")]),
         );
 
-        let report = migrate_v0_to_v1(&paths, &FakeCredentialBackend::default()).unwrap();
+        let report = migrate_to_current(&paths, &FakeCredentialBackend::default()).unwrap();
 
         assert_eq!(report.resume_action, ResumeMigrationAction::Merged);
         let merged: Value =
@@ -606,7 +606,7 @@ browser_config:
         fs::create_dir_all(paths.user_resumes_path().parent().unwrap()).unwrap();
         fs::write(paths.user_resumes_path(), b"{ corrupt").unwrap();
 
-        let report = migrate_v0_to_v1(&paths, &FakeCredentialBackend::default()).unwrap();
+        let report = migrate_to_current(&paths, &FakeCredentialBackend::default()).unwrap();
 
         assert_eq!(report.resume_action, ResumeMigrationAction::TargetRestored);
         assert_eq!(
@@ -630,7 +630,7 @@ browser_config:
         fs::create_dir_all(paths.user_resumes_path().parent().unwrap()).unwrap();
         fs::write(paths.user_resumes_path(), br#"{"broken": 42}"#).unwrap();
 
-        let error = migrate_v0_to_v1(&paths, &FakeCredentialBackend::default()).unwrap_err();
+        let error = migrate_to_current(&paths, &FakeCredentialBackend::default()).unwrap_err();
 
         assert_eq!(error.code, AppErrorCode::Storage);
         assert!(error
@@ -661,11 +661,11 @@ browser_config:
         );
         let backend = FakeCredentialBackend::default();
 
-        let first = migrate_v0_to_v1(&paths, &backend).unwrap();
+        let first = migrate_to_current(&paths, &backend).unwrap();
         let config_after_first = fs::read(&paths.config_path).unwrap();
         let target_after_first = fs::read(paths.user_resumes_path()).unwrap();
         let backups_after_first = fs::read_dir(paths.backups_dir()).unwrap().count();
-        let second = migrate_v0_to_v1(&paths, &backend).unwrap();
+        let second = migrate_to_current(&paths, &backend).unwrap();
 
         assert!(first.migrated);
         assert!(!second.migrated);
@@ -696,7 +696,7 @@ browser_config:
         write_config(&paths, content);
         let backend = FakeCredentialBackend::default();
 
-        let report = migrate_v0_to_v1(&paths, &backend).unwrap();
+        let report = migrate_to_current(&paths, &backend).unwrap();
 
         assert_eq!(backend.value.borrow().as_deref(), Some("plaintext-secret"));
         let migrated = fs::read_to_string(&paths.config_path).unwrap();
@@ -708,7 +708,7 @@ browser_config:
         }
         let raw: Value = serde_yaml::from_str(&migrated).unwrap();
         assert!(raw["llm_config"].get("api_key").is_none());
-        assert!(migrated.contains("schema_version: 1"));
+        assert!(migrated.contains(&format!("schema_version: {CURRENT_SCHEMA_VERSION}")));
     }
 
     #[test]
@@ -731,7 +731,7 @@ browser_config:
             fail_set: true,
         };
 
-        let error = migrate_v0_to_v1(&paths, &backend).unwrap_err();
+        let error = migrate_to_current(&paths, &backend).unwrap_err();
 
         assert_eq!(error.code, AppErrorCode::Credential);
         assert_eq!(fs::read(&paths.config_path).unwrap(), original);
@@ -757,7 +757,7 @@ browser_config:
             fail_set: false,
         };
 
-        migrate_v0_to_v1(&paths, &backend).unwrap();
+        migrate_to_current(&paths, &backend).unwrap();
 
         assert_eq!(backend.value.borrow().as_deref(), Some("newer-secret"));
     }
@@ -774,7 +774,7 @@ browser_config:
             &resume_document(&[("target", "valid")]),
         );
 
-        let report = migrate_v0_to_v1(&paths, &FakeCredentialBackend::default()).unwrap();
+        let report = migrate_to_current(&paths, &FakeCredentialBackend::default()).unwrap();
 
         assert_eq!(
             report.resume_action,
@@ -791,17 +791,20 @@ browser_config:
     fn future_schema_version_aborts_without_touching_config_or_data() {
         let dir = tempfile::tempdir().unwrap();
         let paths = paths(dir.path());
-        let future = b"schema_version: 2\nllm_config: null\n";
-        write_config(&paths, future);
+        let future = format!(
+            "schema_version: {}\nllm_config: null\n",
+            CURRENT_SCHEMA_VERSION + 1
+        );
+        write_config(&paths, future.as_bytes());
         write_json(
             &paths.legacy_user_resumes_path(),
             &resume_document(&[("legacy", "content")]),
         );
 
-        let error = migrate_v0_to_v1(&paths, &FakeCredentialBackend::default()).unwrap_err();
+        let error = migrate_to_current(&paths, &FakeCredentialBackend::default()).unwrap_err();
 
         assert_eq!(error.code, AppErrorCode::Configuration);
-        assert_eq!(fs::read(&paths.config_path).unwrap(), future);
+        assert_eq!(fs::read(&paths.config_path).unwrap(), future.as_bytes());
         assert!(!paths.user_resumes_path().exists());
     }
 
@@ -828,17 +831,17 @@ browser_config:
     }
 
     #[test]
-    fn new_install_starts_directly_at_version_one() {
+    fn new_install_starts_directly_at_current_version() {
         let dir = tempfile::tempdir().unwrap();
         let paths = paths(dir.path());
 
-        let report = migrate_v0_to_v1(&paths, &FakeCredentialBackend::default()).unwrap();
+        let report = migrate_to_current(&paths, &FakeCredentialBackend::default()).unwrap();
 
         assert!(report.migrated);
         let config =
             crate::config::parse_config_content(&fs::read_to_string(&paths.config_path).unwrap())
                 .unwrap();
-        assert_eq!(config.schema_version, 1);
+        assert_eq!(config.schema_version, CURRENT_SCHEMA_VERSION);
         assert!(config.llm_config.is_none());
         assert_eq!(
             config.browser_config.user_data_dir,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Alert, Button, ConfigProvider, Spin, Tabs, Typography } from "antd";
 import { RocketOutlined } from "@ant-design/icons";
 import "./App.css";
 import { useAppConfig } from "@/hooks/useAppConfig";
-import type { AppRuntimeConfig, BrowserConfig, GreetConfig, JobFilterConfig, RegexRule, ReplayConfig, ReplyResource, ReplyTemplate, ResumeConfig } from "@/types/app-config";
+import type { AppRuntimeConfig, BrowserConfig, GreetConfig, GreetResource, JobFilterConfig, RegexRule, ReplayConfig, ReplyResource, ReplyTemplate, ResumeConfig } from "@/types/app-config";
 import { Onboarding } from "@/view/onboarding";
 import { ConfigPage } from "@/view/config";
 import ConversationDebugPage from "@/view/conversation-debug";
@@ -22,6 +22,13 @@ const tabs: Array<{ key: AppTabKey; label: string }> = [
   { key: "config", label: "配置中心" },
 ];
 const updateAt = <T,>(items: T[], index: number, next: Partial<T>) => items.map((item, i) => i === index ? { ...item, ...next } : item);
+const moveAt = <T,>(items: T[], index: number, offset: -1 | 1) => {
+  const target = index + offset;
+  if (target < 0 || target >= items.length) return items;
+  const next = [...items];
+  [next[index], next[target]] = [next[target], next[index]];
+  return next;
+};
 
 function MainShell({ config, update, save, status, message, dirty, importConfig, exportConfig }: {
   config: AppRuntimeConfig; update: (fn: (c: AppRuntimeConfig) => AppRuntimeConfig) => void;
@@ -49,8 +56,9 @@ function MainShell({ config, update, save, status, message, dirty, importConfig,
     persistConfig={() => save()}
     updateJobFilter={(v: Partial<JobFilterConfig>) => merge("job_filter_config", v)}
     updateGreet={(v: Partial<GreetConfig>) => merge("greet_config", v)}
-    updateGreetDefaultResource={(i: number, v: Partial<ReplyResource>) => update((c) => ({ ...c, greet_config: { ...c.greet_config, default_template: updateAt(c.greet_config.default_template, i, v) } }))}
-    addGreetDefaultResource={() => update((c) => ({ ...c, greet_config: { ...c.greet_config, default_template: [...c.greet_config.default_template, { resource_type: "Text", content: "" }] } }))}
+    updateGreetDefaultResource={(i: number, v: Partial<GreetResource>) => update((c) => ({ ...c, greet_config: { ...c.greet_config, default_template: updateAt(c.greet_config.default_template, i, v) } }))}
+    addGreetDefaultResource={(resourceType: GreetResource["resource_type"] = "Text") => update((c) => ({ ...c, greet_config: { ...c.greet_config, default_template: [...c.greet_config.default_template, { resource_type: resourceType, content: "" }] } }))}
+    moveGreetDefaultResource={(i: number, offset: -1 | 1) => update((c) => ({ ...c, greet_config: { ...c.greet_config, default_template: moveAt(c.greet_config.default_template, i, offset) } }))}
     removeGreetDefaultResource={(i: number) => update((c) => ({ ...c, greet_config: { ...c.greet_config, default_template: c.greet_config.default_template.filter((_, x) => x !== i) } }))}
     updateReplay={(v: Partial<ReplayConfig>) => merge("replay_config", v)}
     updateReplyTemplate={(i: number, v: Partial<ReplyTemplate>) => update((c) => ({ ...c, replay_config: { ...c.replay_config, templates: updateAt(c.replay_config.templates, i, v) } }))}

--- a/src/types/app-config.ts
+++ b/src/types/app-config.ts
@@ -104,6 +104,13 @@ export const MAX_RETRY_BASE_DELAY_MS = 10_000;
 
 export type ReplayResourceType = "Text" | "Image" | "LLM";
 
+export interface GreetResource {
+  /** 是否参与发送；旧配置缺失时视为启用 */
+  enabled?: boolean;
+  resource_type: ReplayResourceType;
+  content: string;
+}
+
 export interface ReplyResource {
   resource_type: ReplayResourceType;
   content: string;
@@ -123,7 +130,7 @@ export interface ReplyTemplate {
 export interface GreetConfig {
   enable_llm: boolean;
   reply_prompt: string | null;
-  default_template: ReplyResource[];
+  default_template: GreetResource[];
 }
 
 export interface ReplayConfig {

--- a/src/view/config/index.tsx
+++ b/src/view/config/index.tsx
@@ -26,6 +26,7 @@ import {
   RuleMode,
   JobFilterConfig,
   GreetConfig,
+  GreetResource,
   ReplayConfig,
   ReplyResource,
   ReplyTemplate,
@@ -57,6 +58,10 @@ import {
   InfoCircleOutlined,
   RobotOutlined,
   DatabaseOutlined,
+  ArrowUpOutlined,
+  ArrowDownOutlined,
+  EyeOutlined,
+  EyeInvisibleOutlined,
 } from "@ant-design/icons";
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
@@ -144,9 +149,12 @@ export interface ConfigPageProps {
   updateGreet: (next: Partial<GreetConfig>) => void;
   updateGreetDefaultResource: (
     resourceIndex: number,
-    next: Partial<ReplyResource>,
+    next: Partial<GreetResource>,
   ) => void;
-  addGreetDefaultResource: () => void;
+  addGreetDefaultResource: (
+    resourceType?: GreetResource["resource_type"],
+  ) => void;
+  moveGreetDefaultResource: (resourceIndex: number, offset: -1 | 1) => void;
   removeGreetDefaultResource: (resourceIndex: number) => void;
   updateReplay: (next: Partial<ReplayConfig>) => void;
   updateReplyTemplate: (index: number, next: Partial<ReplyTemplate>) => void;
@@ -340,15 +348,7 @@ export function ConfigPage(props: ConfigPageProps) {
       (resource) => resource.resource_type === "LLM",
     );
 
-  // 先追加一条默认的文本条目，再把它改成 LLM 类型（两次更新都是函数式的，按顺序生效）
-  const addGreetLlmResource = () => {
-    const appendedIndex = props.config.greet_config.default_template.length;
-    props.addGreetDefaultResource();
-    props.updateGreetDefaultResource(appendedIndex, {
-      resource_type: "LLM",
-      content: "",
-    });
-  };
+  const addGreetLlmResource = () => props.addGreetDefaultResource("LLM");
 
   const renderResourceContent = (
     resource: ReplyResource,
@@ -966,10 +966,10 @@ export function ConfigPage(props: ConfigPageProps) {
 
               {props.config.greet_config.enable_llm && !greetTemplateHasLlm && (
                 <Alert
-                  type="info"
+                  type="warning"
                   showIcon
-                  message="模型生成内容将作为第一条自动发送"
-                  description="当前模板里没有 LLM 条目。已启用 LLM 主动沟通时，模型生成的内容会作为第一条发送，随后再依次发送下面的文本条目。若想自己控制它在模板中的位置，可手动添加一条 LLM 内容。"
+                  message="发送序列中尚未添加 LLM 内容"
+                  description="大模型不会被隐式插入发送。添加 LLM 内容并启用后，才会在对应位置生成并发送。"
                   action={
                     <Button
                       size="small"
@@ -987,16 +987,16 @@ export function ConfigPage(props: ConfigPageProps) {
                 <div className="flex items-center justify-between">
                   <div>
                     <Text className="text-slate-900 font-bold block">
-                      默认打招呼模板
+                      打招呼发送顺序
                     </Text>
                     <Text className="text-slate-500 text-xs">
-                      按顺序发送的固定内容；启用 LLM 时，模型生成内容也会与这些条目一并发送
+                      仅启用的内容会按从上到下依次发送
                     </Text>
                   </div>
                   <Button
                     type="text"
                     icon={<PlusOutlined />}
-                    onClick={props.addGreetDefaultResource}
+                    onClick={() => props.addGreetDefaultResource()}
                     className="text-sky-500! hover:bg-sky-50! rounded-lg! font-bold"
                   >
                     添加内容
@@ -1008,17 +1008,26 @@ export function ConfigPage(props: ConfigPageProps) {
                     (resource, index) => (
                       <div
                         key={index}
-                        className="grid grid-cols-1 md:grid-cols-[120px_1fr_40px] gap-3 items-start"
+                        className="grid grid-cols-1 md:grid-cols-[40px_120px_minmax(0,1fr)_auto] gap-3 items-start rounded-2xl border border-slate-200/80 bg-white p-3 shadow-sm transition-shadow hover:shadow-md"
                       >
+                        <div className="flex h-8 items-center justify-center rounded-lg bg-sky-50 text-xs font-bold text-sky-600">
+                          {index + 1}
+                        </div>
                         <Select
                           value={resource.resource_type}
                           onChange={(value) =>
                             props.updateGreetDefaultResource(index, {
                               resource_type:
-                                value as ReplyResource["resource_type"],
+                                value as GreetResource["resource_type"],
                             })
                           }
-                          options={resourceTypeOptions()}
+                          options={resourceTypeOptions().map((option) => ({
+                            ...option,
+                            disabled:
+                              option.value === "LLM" &&
+                              greetTemplateHasLlm &&
+                              resource.resource_type !== "LLM",
+                          }))}
                         />
                         {renderResourceContent(
                           resource,
@@ -1032,14 +1041,76 @@ export function ConfigPage(props: ConfigPageProps) {
                               content,
                             }),
                         )}
-                        <Button
-                          type="text"
-                          danger
-                          icon={<DeleteOutlined />}
-                          onClick={() =>
-                            props.removeGreetDefaultResource(index)
-                          }
-                        />
+                        <div className="flex items-center justify-self-end rounded-xl border border-slate-200 bg-slate-50/80 p-1 shadow-inner">
+                          <div className="flex items-center gap-0.5 pr-1">
+                            <Button
+                              type="text"
+                              title="上移"
+                              aria-label={`上移第 ${index + 1} 条打招呼内容`}
+                              icon={<ArrowUpOutlined />}
+                              disabled={index === 0}
+                              onClick={() =>
+                                props.moveGreetDefaultResource(index, -1)
+                              }
+                              className="h-8! w-8! min-w-8! rounded-lg! p-0! text-slate-600! hover:bg-white! hover:shadow-sm!"
+                            />
+                            <Button
+                              type="text"
+                              title="下移"
+                              aria-label={`下移第 ${index + 1} 条打招呼内容`}
+                              icon={<ArrowDownOutlined />}
+                              disabled={
+                                index ===
+                                props.config.greet_config.default_template.length - 1
+                              }
+                              onClick={() =>
+                                props.moveGreetDefaultResource(index, 1)
+                              }
+                              className="h-8! w-8! min-w-8! rounded-lg! p-0! text-slate-600! hover:bg-white! hover:shadow-sm!"
+                            />
+                          </div>
+                          <div className="h-5 w-px bg-slate-200" />
+                          <Button
+                            title={
+                              resource.enabled === false
+                                ? "启用发送"
+                                : "停用发送"
+                            }
+                            aria-label={`${
+                              resource.enabled === false ? "启用" : "停用"
+                            }第 ${index + 1} 条打招呼内容`}
+                            type="text"
+                            className={
+                              resource.enabled === false
+                                ? "mx-1! h-8! w-8! min-w-8! rounded-lg! p-0! text-slate-500! hover:bg-white!"
+                                : "mx-1! h-8! w-8! min-w-8! rounded-lg! bg-emerald-50! p-0! text-emerald-600! hover:bg-emerald-100!"
+                            }
+                            icon={
+                              resource.enabled === false ? (
+                                <EyeInvisibleOutlined />
+                              ) : (
+                                <EyeOutlined />
+                              )
+                            }
+                            onClick={() =>
+                              props.updateGreetDefaultResource(index, {
+                                enabled: resource.enabled === false,
+                              })
+                            }
+                          />
+                          <div className="h-5 w-px bg-slate-200" />
+                          <Button
+                            type="text"
+                            title="删除"
+                            aria-label={`删除第 ${index + 1} 条打招呼内容`}
+                            danger
+                            icon={<DeleteOutlined />}
+                            onClick={() =>
+                              props.removeGreetDefaultResource(index)
+                            }
+                            className="ml-1! h-8! w-8! min-w-8! rounded-lg! p-0! hover:bg-red-50!"
+                          />
+                        </div>
                       </div>
                     ),
                   )}


### PR DESCRIPTION
## 变更内容
- 将 LLM 问候语和模板问候语改为可排序、可单独启停的发送序列。
- 统一 BOSS 与猎聘的问候语资源组合逻辑。
- 增加配置迁移，保持现有用户配置行为不变。

## 影响
用户可明确控制 LLM 和模板问候语的发送顺序及启用状态。

## 验证
未在本次推送流程中重新运行自动化测试；仅发布既有功能提交。