### PR TITLE
feat: 支持猎聘 IM 沟通与并行求职任务

### DIFF
--- a/src-tauri/src/browser.rs
+++ b/src-tauri/src/browser.rs
@@ -6,7 +6,10 @@ use std::{
     path::PathBuf,
     pin::Pin,
     process::{Command, Stdio},
-    sync::RwLock,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex, RwLock,
+    },
     time::Duration,
 };
 
@@ -136,6 +139,11 @@ static BROWSER_SESSION: Lazy<RwLock<BrowserSession>> =
     Lazy::new(|| RwLock::new(BrowserSession::Empty));
 static APP_HANDLE: Lazy<RwLock<Option<tauri::AppHandle>>> = Lazy::new(|| RwLock::new(None));
 static ACTIVE_DEBUG_PORT: Lazy<RwLock<Option<u16>>> = Lazy::new(|| RwLock::new(None));
+/// Serializes the check-and-launch sequence. `BROWSER_SESSION` also protects its
+/// own state, but this lock additionally closes the race between ensuring the
+/// managed process and establishing a task-scoped CDP connection.
+static MANAGED_BROWSER_START_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static ACTIVE_TASK_BROWSER_LEASES: AtomicUsize = AtomicUsize::new(0);
 
 const DEFAULT_RPA_DEBUG_PORT: u16 = 9876;
 const BROWSER_START_ATTEMPTS: usize = 3;
@@ -151,6 +159,91 @@ enum BrowserSession {
     Empty,
     Ready(ChromiumPage),
     InUse { close_requested: bool },
+}
+
+/// Tabs created through a task lease. Keeping ownership explicit is important:
+/// taking a before/after snapshot of all Chrome tabs is racy when two tasks
+/// create tabs at the same time.
+struct TaskOwnedTabs<T> {
+    tabs: Vec<T>,
+}
+
+impl<T> Default for TaskOwnedTabs<T> {
+    fn default() -> Self {
+        Self { tabs: Vec::new() }
+    }
+}
+
+impl<T> TaskOwnedTabs<T> {
+    fn register(&mut self, tab: T) {
+        self.tabs.push(tab);
+    }
+
+    fn drain(&mut self) -> Vec<T> {
+        std::mem::take(&mut self.tabs)
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.tabs.len()
+    }
+}
+
+/// A task-isolated CDP connection and the tabs created through it.
+///
+/// The underlying `ChromiumPage` is deliberately only exposed by shared
+/// reference. This prevents task code from calling `close_browser()`, while
+/// still allowing it to create listeners and use browser-level read APIs.
+pub struct TaskBrowserLease {
+    browser: ChromiumPage,
+    main_tab: Page,
+    owned_tabs: Mutex<TaskOwnedTabs<Page>>,
+    counted_active: bool,
+}
+
+impl TaskBrowserLease {
+    /// The task's dedicated initial tab.
+    pub fn tab(&self) -> &Page {
+        &self.main_tab
+    }
+
+    /// The task's independent CDP connection. Only a shared reference is
+    /// returned, so this lease cannot terminate the managed Chrome process.
+    pub fn browser(&self) -> &ChromiumPage {
+        &self.browser
+    }
+
+    /// Create another stealth tab owned by this task. It will be closed along
+    /// with the main tab when the lease finishes.
+    pub fn new_stealth_tab(&self) -> Result<Page> {
+        let tab = new_stealth_tab(&self.browser)?;
+        self.owned_tabs
+            .lock()
+            .map_err(|e| anyhow!("获取任务标签页锁失败: {}", e))?
+            .register(tab.clone());
+        Ok(tab)
+    }
+
+    fn close_owned_tabs(&self) -> Result<()> {
+        let tabs = self
+            .owned_tabs
+            .lock()
+            .map_err(|e| anyhow!("获取任务标签页锁失败: {}", e))?
+            .drain();
+        close_task_owned_tabs(tabs)
+    }
+}
+
+impl Drop for TaskBrowserLease {
+    fn drop(&mut self) {
+        // Best-effort fallback for cancellation/panic paths. `with_task_browser`
+        // performs the same cleanup explicitly so it can report an error.
+        let _ = self.close_owned_tabs();
+        if self.counted_active {
+            ACTIVE_TASK_BROWSER_LEASES.fetch_sub(1, Ordering::AcqRel);
+            self.counted_active = false;
+        }
+    }
 }
 
 pub fn init_app_handle(app_handle: tauri::AppHandle) -> Result<()> {
@@ -191,13 +284,19 @@ pub fn init_browser_session(config: &BrowserConfig) -> Result<()> {
             }
         }
         BrowserSession::InUse { .. } => {
-            // 如果任务已经不在运行了，说明 InUse 是残留的卡死状态，
-            // 强制清理为 Empty 以便重新初始化浏览器。
-            if !crate::rpa::run_flow::is_job_task_running() {
-                *session = BrowserSession::Empty;
-            } else {
+            // A legacy `with_browser` caller currently owns the anchor
+            // connection. Task-scoped callers can still attach through CDP;
+            // never reset the anchor here because that would race its later
+            // restore and could launch/attach a second session unnecessarily.
+            let active_port = ACTIVE_DEBUG_PORT
+                .read()
+                .ok()
+                .and_then(|port| *port)
+                .is_some_and(is_cdp_port_active);
+            if active_port {
                 return Ok(());
             }
+            return Err(anyhow!("浏览器会话正在初始化或使用中，请稍后重试"));
         }
         BrowserSession::Empty => {}
     }
@@ -299,6 +398,18 @@ fn connect_to_browser(port: u16) -> Result<ChromiumPage> {
         Ok(browser)
     } else {
         Err(anyhow!("浏览器调试端口 {port} 的会话不可用"))
+    }
+}
+
+/// Establish a connection for one task without touching the tab selected by
+/// `ChromiumPage::connect`. The caller immediately creates its own tab below.
+fn connect_task_browser(port: u16) -> Result<ChromiumPage> {
+    let endpoint = format!("127.0.0.1:{port}");
+    let browser = ChromiumPage::connect(&endpoint)?;
+    if is_browser_session_usable(&browser) {
+        Ok(browser)
+    } else {
+        Err(anyhow!("浏览器调试端口 {port} 的任务连接不可用"))
     }
 }
 
@@ -440,6 +551,96 @@ where
     result
 }
 
+/// Run one RPA task on an independent CDP connection and an independently
+/// owned main tab.
+///
+/// Calls may run concurrently. Chrome/profile startup is serialized, but the
+/// lock is released before the task begins. Cleanup closes only tabs registered
+/// to this lease; it never closes Chrome or tabs belonging to another task.
+pub async fn with_task_browser<T, F>(op: F) -> Result<T>
+where
+    F: for<'a> FnOnce(&'a ChromiumPage, &'a Page) -> Pin<Box<dyn Future<Output = Result<T>> + 'a>>,
+{
+    let config = load_browser_config()?;
+    let start_guard = MANAGED_BROWSER_START_LOCK
+        .lock()
+        .map_err(|e| anyhow!("获取浏览器启动锁失败: {}", e))?;
+    let port = ensure_managed_browser_for_task(&config)?;
+    // Count the task while still holding the lifecycle lock. This closes the
+    // gap in which an explicit browser-close request could otherwise arrive
+    // after startup but before the lease became visible.
+    ACTIVE_TASK_BROWSER_LEASES.fetch_add(1, Ordering::AcqRel);
+    drop(start_guard);
+
+    let browser = match connect_task_browser(port) {
+        Ok(browser) => browser,
+        Err(error) => {
+            ACTIVE_TASK_BROWSER_LEASES.fetch_sub(1, Ordering::AcqRel);
+            return Err(error);
+        }
+    };
+    let main_tab = match new_stealth_tab(&browser) {
+        Ok(tab) => tab,
+        Err(error) => {
+            ACTIVE_TASK_BROWSER_LEASES.fetch_sub(1, Ordering::AcqRel);
+            return Err(error);
+        }
+    };
+    let mut owned_tabs = TaskOwnedTabs::default();
+    owned_tabs.register(main_tab.clone());
+
+    let lease = TaskBrowserLease {
+        browser,
+        main_tab,
+        owned_tabs: Mutex::new(owned_tabs),
+        counted_active: true,
+    };
+    let result = op(lease.browser(), lease.tab()).await;
+    // Closing a tab after its renderer/browser has already exited is benign
+    // for task cleanup. Never turn an otherwise successful RPA task into a
+    // failure solely because best-effort teardown could not close a dead tab.
+    let _ = lease.close_owned_tabs();
+
+    result
+}
+
+fn ensure_managed_browser_for_task(config: &BrowserConfig) -> Result<u16> {
+    // The legacy session owns no task connection. It remains as the process
+    // health anchor for environment/login APIs and also serializes launch with
+    // callers that have not migrated to task leases yet.
+    init_browser_session(config)?;
+
+    let port = ACTIVE_DEBUG_PORT
+        .read()
+        .map_err(|e| anyhow!("获取浏览器调试端口读锁失败: {}", e))?
+        .ok_or_else(|| anyhow!("浏览器已初始化但调试端口未知"))?;
+    if !is_cdp_port_active(port) {
+        return Err(anyhow!("浏览器调试端口 {port} 不可用"));
+    }
+    Ok(port)
+}
+
+fn close_task_owned_tabs(tabs: Vec<Page>) -> Result<()> {
+    close_owned_items(tabs, |tab| tab.close().map_err(anyhow::Error::from))
+}
+
+/// Close every owned resource even when one close fails. Returning the first
+/// error preserves useful diagnostics without leaking the remaining tabs.
+fn close_owned_items<T, F>(items: Vec<T>, mut close: F) -> Result<()>
+where
+    F: FnMut(T) -> Result<()>,
+{
+    let mut first_error = None;
+    for item in items {
+        if let Err(error) = close(item) {
+            if first_error.is_none() {
+                first_error = Some(error);
+            }
+        }
+    }
+    first_error.map_or(Ok(()), Err)
+}
+
 fn take_browser_session() -> Result<ChromiumPage> {
     let mut session = BROWSER_SESSION
         .write()
@@ -474,18 +675,29 @@ fn restore_browser_session(mut browser: ChromiumPage, error: Option<&anyhow::Err
             close_requested: true
         }
     );
-    *session =
-        if close_requested || error.is_some_and(|err| !reuse_browser_session_after_error(err)) {
-            browser.close_browser();
-            BrowserSession::Empty
-        } else {
-            BrowserSession::Ready(browser)
-        };
+    let task_leases_active = ACTIVE_TASK_BROWSER_LEASES.load(Ordering::Acquire) > 0;
+    *session = if !task_leases_active && close_requested {
+        browser.close_browser();
+        BrowserSession::Empty
+    } else if error.is_some_and(|err| !reuse_browser_session_after_error(err)) {
+        // Discard the broken CDP connection, but do not terminate the managed
+        // Chrome process: another task may be between connection setup and
+        // lease publication. The next initialization can reconnect by port.
+        BrowserSession::Empty
+    } else {
+        BrowserSession::Ready(browser)
+    };
 
     Ok(())
 }
 
 pub fn close_browser_session() -> Result<()> {
+    let _lifecycle_guard = MANAGED_BROWSER_START_LOCK
+        .lock()
+        .map_err(|e| anyhow!("获取浏览器生命周期锁失败: {}", e))?;
+    if ACTIVE_TASK_BROWSER_LEASES.load(Ordering::Acquire) > 0 {
+        return Err(anyhow!("仍有自动化任务正在使用浏览器，暂不能关闭"));
+    }
     let mut session = BROWSER_SESSION
         .write()
         .map_err(|e| anyhow!("获取浏览器会话写锁失败: {}", e))?;
@@ -618,6 +830,7 @@ mod tests {
         let config = BrowserConfig {
             user_data_dir: "/tmp/offer-flow-profile".to_string(),
             chrome_exe_path: None,
+            max_parallel_tasks: 2,
         };
         let record = ManagedBrowserRecord {
             pid: 123,
@@ -632,5 +845,45 @@ mod tests {
     #[test]
     fn cdp_connections_install_stealth_before_the_next_navigation() {
         assert!(cdp_connection_requires_stealth_injection());
+    }
+
+    #[test]
+    fn task_owned_tabs_track_only_explicitly_registered_tabs() {
+        let mut owned = TaskOwnedTabs::default();
+        owned.register("task-main");
+        owned.register("task-child");
+
+        assert_eq!(owned.len(), 2);
+        assert_eq!(owned.drain(), vec!["task-main", "task-child"]);
+        assert_eq!(owned.len(), 0);
+    }
+
+    #[test]
+    fn task_cleanup_attempts_every_owned_tab_and_reports_first_error() {
+        let mut closed = Vec::new();
+        let result = close_owned_items(vec![1, 2, 3], |tab_id| {
+            closed.push(tab_id);
+            if tab_id == 2 {
+                Err(anyhow!("tab 2 close failed"))
+            } else {
+                Ok(())
+            }
+        });
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "tab 2 close failed");
+        assert_eq!(closed, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn task_cleanup_with_no_owned_tabs_is_a_noop() {
+        let mut close_called = false;
+        let result = close_owned_items(Vec::<u8>::new(), |_| {
+            close_called = true;
+            Ok(())
+        });
+
+        assert!(result.is_ok());
+        assert!(!close_called);
     }
 }

--- a/src-tauri/src/command/communicated_jobs.rs
+++ b/src-tauri/src/command/communicated_jobs.rs
@@ -386,6 +386,10 @@ fn merge_collected_job_detail(
         Some(existing) => JobDetail {
             id: collected.id,
             platform: "boss".to_string(),
+            source_task_id: existing.source_task_id,
+            profile_id: existing.profile_id,
+            profile_name: existing.profile_name,
+            profile_snapshot_id: existing.profile_snapshot_id,
             title: prefer_new(collected.title, existing.title),
             company_name: prefer_new(collected.company_name, existing.company_name),
             detail: prefer_new(collected.detail, existing.detail),
@@ -400,6 +404,10 @@ fn merge_collected_job_detail(
         None => JobDetail {
             id: collected.id,
             platform: "boss".to_string(),
+            source_task_id: None,
+            profile_id: None,
+            profile_name: None,
+            profile_snapshot_id: None,
             title: collected.title,
             company_name: collected.company_name,
             detail: collected.detail,
@@ -564,6 +572,10 @@ mod tests {
         JobDetail {
             id: "abc123".to_string(),
             platform: "boss".to_string(),
+            source_task_id: None,
+            profile_id: None,
+            profile_name: None,
+            profile_snapshot_id: None,
             title: "旧标题".to_string(),
             company_name: "旧公司".to_string(),
             detail: "旧 JD".to_string(),

--- a/src-tauri/src/command/data_management.rs
+++ b/src-tauri/src/command/data_management.rs
@@ -1,5 +1,5 @@
 use crate::command::base::CommandResult;
-use crate::dao::{analysis_dao, chat_message_dao, job_detail_dao, model::*};
+use crate::dao::{analysis_dao, chat_message_dao, job_detail_dao, model::*, profile_snapshot_dao};
 use anyhow::{Context, Result};
 use chrono::Local;
 use serde::{Deserialize, Serialize};
@@ -16,6 +16,8 @@ pub struct BackupStats {
     pub chat_messages_count: usize,
     pub interview_analyses_count: usize,
     pub user_resumes_count: usize,
+    #[serde(default)]
+    pub job_profile_snapshots_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,6 +38,10 @@ pub struct ImportResultStats {
     pub interview_analyses_updated: usize,
     pub user_resumes_added: usize,
     pub config_imported: bool,
+    #[serde(default)]
+    pub job_profile_snapshots_added: usize,
+    #[serde(default)]
+    pub job_profile_snapshots_updated: usize,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -74,6 +80,7 @@ fn export_data_bundle_inner(
     let jobs = job_detail_dao::list().unwrap_or_default();
     let chats = chat_message_dao::list().unwrap_or_default();
     let analyses = analysis_dao::list().unwrap_or_default();
+    let profile_snapshots = profile_snapshot_dao::list().unwrap_or_default();
 
     let user_resumes_file = user_resumes_path(&data_dir);
     let user_resumes_content = if user_resumes_file.exists() {
@@ -91,6 +98,7 @@ fn export_data_bundle_inner(
         chat_messages_count: chats.len(),
         interview_analyses_count: analyses.len(),
         user_resumes_count,
+        job_profile_snapshots_count: profile_snapshots.len(),
     };
 
     let manifest = ExportManifest {
@@ -116,6 +124,9 @@ fn export_data_bundle_inner(
 
     zip.start_file("data/interview_analyses.json", options)?;
     zip.write_all(serde_json::to_string_pretty(&analyses)?.as_bytes())?;
+
+    zip.start_file("data/job_profile_snapshots.json", options)?;
+    zip.write_all(serde_json::to_string_pretty(&profile_snapshots)?.as_bytes())?;
 
     zip.start_file("data/user_resumes.json", options)?;
     zip.write_all(user_resumes_content.as_bytes())?;
@@ -192,6 +203,8 @@ fn import_data_bundle_inner(
         interview_analyses_updated: 0,
         user_resumes_added: 0,
         config_imported: false,
+        job_profile_snapshots_added: 0,
+        job_profile_snapshots_updated: 0,
     };
 
     // 1. 导入/合并 JobDetails — 批量操作，只读写各一次
@@ -259,7 +272,26 @@ fn import_data_bundle_inner(
         }
     }
 
-    // 4. 导入/合并 UserResumes
+    // 4. 导入不可变求职方案快照。老备份不含此文件，保持向后兼容。
+    if let Ok(mut file) = zip.by_name("data/job_profile_snapshots.json") {
+        let mut content = String::new();
+        file.read_to_string(&mut content)?;
+        if let Ok(incoming) = serde_json::from_str::<Vec<JobProfileSnapshot>>(&content) {
+            match strategy {
+                ImportStrategy::Overwrite => {
+                    result_stats.job_profile_snapshots_added = incoming.len();
+                    profile_snapshot_dao::replace_all(incoming)?;
+                }
+                ImportStrategy::Merge => {
+                    let batch = profile_snapshot_dao::batch_upsert(incoming)?;
+                    result_stats.job_profile_snapshots_added = batch.added;
+                    result_stats.job_profile_snapshots_updated = batch.updated;
+                }
+            }
+        }
+    }
+
+    // 5. 导入/合并 UserResumes
     if let Ok(mut file) = zip.by_name("data/user_resumes.json") {
         let mut content = String::new();
         file.read_to_string(&mut content)?;
@@ -289,15 +321,17 @@ fn import_data_bundle_inner(
         }
     }
 
-    // 5. 可选导入应用配置
+    // 6. 可选导入应用配置
     if import_config {
         if let Ok(mut file) = zip.by_name("config.yaml") {
             let mut content = String::new();
             file.read_to_string(&mut content)?;
-            if let Ok(cfg) = serde_yaml::from_str::<crate::config::AppRuntimeConfig>(&content) {
-                if crate::config::save_app_config_inner(app_handle.clone(), cfg).is_ok() {
-                    result_stats.config_imported = true;
-                }
+            // 统一走应用自己的兼容解析器。直接反序列化 v0-v2 备份会得到空的
+            // job_profiles，随后被 v3 校验拒绝，也无法把旧五块策略迁移为默认方案。
+            if let Ok(cfg) = crate::config::parse_config_content(&content) {
+                crate::config::save_app_config_inner(app_handle.clone(), cfg)
+                    .context("导入应用配置失败")?;
+                result_stats.config_imported = true;
             }
         }
     }

--- a/src-tauri/src/command/llm_provider.rs
+++ b/src-tauri/src/command/llm_provider.rs
@@ -139,7 +139,9 @@ fn find_chain_link<'a>(
         .iter()
         .find(|link| link.id == entry_id)
         .ok_or_else(|| {
-            AppError::configuration("未找到该大模型服务，请先保存配置后再测试；未保存或已停用的服务无法测试")
+            AppError::configuration(
+                "未找到该大模型服务，请先保存配置后再测试；未保存或已停用的服务无法测试",
+            )
         })
 }
 
@@ -498,7 +500,10 @@ mod tests {
 
         assert_eq!(statuses.len(), entry_ids.len());
         assert_eq!(
-            statuses.iter().map(|s| s.entry_id.as_str()).collect::<Vec<_>>(),
+            statuses
+                .iter()
+                .map(|s| s.entry_id.as_str())
+                .collect::<Vec<_>>(),
             vec![PRIMARY_LLM_ENTRY_ID, "backup-b", "backup-a"]
         );
         assert_eq!(

--- a/src-tauri/src/command/rpa/run_flow.rs
+++ b/src-tauri/src/command/rpa/run_flow.rs
@@ -1,9 +1,10 @@
 use crate::{
     command::base::CommandResult,
-    config::load_app_config,
+    config::{load_app_config, resolve_job_profile},
+    dao::{model::JobProfileSnapshot, profile_snapshot_dao},
     logger,
     rpa::run_flow::{self, EnvCheckResult, FlowMode, PlatformKind, ReadinessReport},
-    task::{JobTaskInfo, JobTaskOverview, JOB_TASK_MANAGER},
+    task::{JobTaskInfo, JobTaskOverview, JobTaskProfile, JOB_TASK_MANAGER},
 };
 
 #[tauri::command]
@@ -192,14 +193,51 @@ pub fn start_job_task(
     platform: PlatformKind,
     mode: FlowMode,
     interval_minutes: Option<u64>,
+    profile_id: Option<String>,
 ) -> CommandResult<JobTaskInfo> {
     if mode == FlowMode::PeriodicJobHunting && interval_minutes.is_none_or(|minutes| minutes == 0) {
         return CommandResult::err("周期性投递间隔必须大于 0 分钟");
     }
 
-    let config = match crate::config::load_app_config_inner(app_handle) {
+    let base_config = match crate::config::load_app_config_inner(app_handle) {
         Ok(config) => config,
         Err(error) => return CommandResult::err(error),
+    };
+    let (config, task_profile) = match mode {
+        FlowMode::JobHunting | FlowMode::PeriodicJobHunting => {
+            let resolved = match resolve_job_profile(&base_config, profile_id.as_deref()) {
+                Ok(resolved) => resolved,
+                Err(error) => return CommandResult::err(error),
+            };
+            let Some(snapshot) = JobProfileSnapshot::from_resolved(&resolved.config) else {
+                return CommandResult::err("创建求职方案快照失败：缺少活动方案元信息");
+            };
+            if let Err(error) = profile_snapshot_dao::upsert(snapshot) {
+                return CommandResult::err(format!("保存求职方案快照失败：{error}"));
+            }
+            let profile = JobTaskProfile {
+                profile_id: Some(resolved.profile_id),
+                profile_name: Some(resolved.profile_name),
+                profile_snapshot_id: Some(resolved.snapshot_id),
+            };
+            (resolved.config, Some(profile))
+        }
+        FlowMode::ReplyUnread => {
+            // 回复任务会逐会话恢复首次建联快照，不能在整批任务上固定一张方案。
+            let config = match resolve_job_profile(&base_config, None) {
+                Ok(resolved) => resolved.config,
+                Err(error) => return CommandResult::err(error),
+            };
+            (
+                config,
+                Some(JobTaskProfile {
+                    profile_id: None,
+                    profile_name: Some("按会话自动选择".to_string()),
+                    profile_snapshot_id: None,
+                }),
+            )
+        }
+        FlowMode::SyncChatHistory => (base_config, None),
     };
     let readiness = run_flow::inspect_readiness(platform, mode, &config);
     if !readiness.ready {
@@ -213,7 +251,7 @@ pub fn start_job_task(
         return CommandResult::err(format!("任务准备未完成：{missing}"));
     }
 
-    match JOB_TASK_MANAGER.submit(platform, mode, interval_minutes, config) {
+    match JOB_TASK_MANAGER.submit(platform, mode, interval_minutes, config, task_profile) {
         Ok(task) => CommandResult::ok(task),
         Err(error) => CommandResult::err(error),
     }

--- a/src-tauri/src/command/rpa/run_flow.rs
+++ b/src-tauri/src/command/rpa/run_flow.rs
@@ -2,7 +2,8 @@ use crate::{
     command::base::CommandResult,
     config::load_app_config,
     logger,
-    rpa::run_flow::{self, EnvCheckResult, FlowMode, JobTaskStatus, PlatformKind, ReadinessReport},
+    rpa::run_flow::{self, EnvCheckResult, FlowMode, PlatformKind, ReadinessReport},
+    task::{JobTaskInfo, JobTaskOverview, JOB_TASK_MANAGER},
 };
 
 #[tauri::command]
@@ -150,6 +151,10 @@ pub async fn rpa_flow(
 
     let (tx, rx) = tokio::sync::oneshot::channel();
     std::thread::spawn(move || {
+        // Logger context is thread-local. Legacy callers still execute the
+        // actual flow on a dedicated worker, so install the platform again on
+        // that thread instead of relying on the command thread's context.
+        let _log_context = logger::scoped_context(None, Some(platform));
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build();
@@ -177,6 +182,43 @@ pub async fn rpa_flow(
     command_result
 }
 
+/// Enqueues a browser automation job and returns immediately.
+///
+/// The scheduler applies a global concurrency limit and a capacity-one lock per platform. The
+/// actual flow continues to run on its own OS thread with a current-thread Tokio runtime.
+#[tauri::command]
+pub fn start_job_task(
+    app_handle: tauri::AppHandle,
+    platform: PlatformKind,
+    mode: FlowMode,
+    interval_minutes: Option<u64>,
+) -> CommandResult<JobTaskInfo> {
+    if mode == FlowMode::PeriodicJobHunting && interval_minutes.is_none_or(|minutes| minutes == 0) {
+        return CommandResult::err("周期性投递间隔必须大于 0 分钟");
+    }
+
+    let config = match crate::config::load_app_config_inner(app_handle) {
+        Ok(config) => config,
+        Err(error) => return CommandResult::err(error),
+    };
+    let readiness = run_flow::inspect_readiness(platform, mode, &config);
+    if !readiness.ready {
+        let missing = readiness
+            .items
+            .iter()
+            .filter(|item| item.level == run_flow::ReadinessLevel::Blocked)
+            .map(|item| item.label.as_str())
+            .collect::<Vec<_>>()
+            .join("、");
+        return CommandResult::err(format!("任务准备未完成：{missing}"));
+    }
+
+    match JOB_TASK_MANAGER.submit(platform, mode, interval_minutes, config) {
+        Ok(task) => CommandResult::ok(task),
+        Err(error) => CommandResult::err(error),
+    }
+}
+
 fn flow_error_message(
     result: &Result<Result<(), anyhow::Error>, tokio::sync::oneshot::error::RecvError>,
 ) -> Option<String> {
@@ -202,13 +244,19 @@ fn command_result_for_flow(
 }
 
 #[tauri::command]
-pub fn get_job_task_status() -> CommandResult<JobTaskStatus> {
-    CommandResult::ok(run_flow::get_job_task_status())
+pub fn get_job_task_status() -> CommandResult<JobTaskOverview> {
+    CommandResult::ok(JOB_TASK_MANAGER.overview())
 }
 
 #[tauri::command]
-pub fn stop_job_task() -> CommandResult<()> {
-    match run_flow::stop_job_task() {
+pub fn stop_job_task(task_id: Option<String>) -> CommandResult<()> {
+    let result = match task_id {
+        Some(task_id) => JOB_TASK_MANAGER.stop(&task_id),
+        // Keep the pre-queue command contract working for callers that still
+        // invoke `rpa_flow`/`boss_flow` directly.
+        None => run_flow::stop_job_task(),
+    };
+    match result {
         Ok(()) => CommandResult::ok(()),
         Err(error) => CommandResult::err(error),
     }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -13,6 +13,8 @@ use crate::{
 
 const CONFIG_FILE_NAME: &str = "app_config.yaml";
 pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+pub const MIN_PARALLEL_TASKS: usize = 1;
+pub const MAX_PARALLEL_TASKS: usize = 2;
 
 const DEFAULT_CONFIG_YAML: &str = include_str!("resource/app_config.yaml");
 
@@ -68,6 +70,7 @@ pub fn default_app_config() -> AppRuntimeConfig {
         browser_config: BrowserConfig {
             user_data_dir: "".to_string(),
             chrome_exe_path: None,
+            max_parallel_tasks: default_max_parallel_tasks(),
         },
         resume_config: ResumeConfig {
             inject_llm_context: false,
@@ -345,6 +348,10 @@ pub fn validate_and_normalize(config: &mut AppRuntimeConfig) -> Result<(), Strin
     normalize_llm_retry_config(&mut config.llm_retry_config);
     normalize_llm_fallbacks(&mut config.llm_fallbacks)?;
     validate_greet_template(&config.greet_config)?;
+    config.browser_config.max_parallel_tasks = config
+        .browser_config
+        .max_parallel_tasks
+        .clamp(MIN_PARALLEL_TASKS, MAX_PARALLEL_TASKS);
 
     let Some(llm_config) = config.llm_config.as_mut() else {
         return Ok(());
@@ -992,6 +999,13 @@ pub struct BrowserConfig {
     /// 浏览器执行路径
     #[serde(default)]
     pub chrome_exe_path: Option<String>,
+    /// 同时执行的自动化任务上限。当前仅开放跨平台双任务并行。
+    #[serde(default = "default_max_parallel_tasks")]
+    pub max_parallel_tasks: usize,
+}
+
+fn default_max_parallel_tasks() -> usize {
+    2
 }
 
 // ================================
@@ -1494,6 +1508,24 @@ greet_config:
             config.llm_retry_config.retry_base_delay_ms,
             MAX_RETRY_BASE_DELAY_MS
         );
+    }
+
+    #[test]
+    fn browser_parallelism_defaults_to_two_and_is_clamped_to_supported_range() {
+        let legacy = parse_config_content(
+            "schema_version: 2\nbrowser_config:\n  user_data_dir: profile\n  chrome_exe_path: null\n",
+        )
+        .unwrap();
+        assert_eq!(legacy.browser_config.max_parallel_tasks, 2);
+
+        let mut config = default_app_config();
+        config.browser_config.max_parallel_tasks = 99;
+        validate_and_normalize(&mut config).unwrap();
+        assert_eq!(config.browser_config.max_parallel_tasks, MAX_PARALLEL_TASKS);
+
+        config.browser_config.max_parallel_tasks = 0;
+        validate_and_normalize(&mut config).unwrap();
+        assert_eq!(config.browser_config.max_parallel_tasks, MIN_PARALLEL_TASKS);
     }
 
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -12,9 +12,11 @@ use crate::{
 };
 
 const CONFIG_FILE_NAME: &str = "app_config.yaml";
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+pub const CURRENT_SCHEMA_VERSION: u32 = 3;
 pub const MIN_PARALLEL_TASKS: usize = 1;
 pub const MAX_PARALLEL_TASKS: usize = 2;
+pub const DEFAULT_JOB_PROFILE_ID: &str = "default";
+pub const DEFAULT_JOB_PROFILE_NAME: &str = "默认求职方案";
 
 const DEFAULT_CONFIG_YAML: &str = include_str!("resource/app_config.yaml");
 
@@ -34,49 +36,69 @@ fn default_greet_config() -> GreetConfig {
 }
 
 pub fn default_app_config() -> AppRuntimeConfig {
+    let job_filter_config = JobFilterConfig {
+        query: Some("Rust 工程师".to_string()),
+        city: None,
+        job_type: 0,
+        salary: 0,
+        experience: Vec::new(),
+        dgree: Vec::new(),
+        industry: Vec::new(),
+        scale: Vec::new(),
+        stage: Vec::new(),
+        keywords: Vec::new(),
+        exclude_keywords: Vec::new(),
+        company_keywords: Vec::new(),
+        company_exclude_keywords: Vec::new(),
+        enable_semantic_filter: false,
+        semantic_filter_intent: None,
+        regex_rules: Vec::new(),
+    };
+    let platform_filter_config = PlatformFilterConfig::default();
+    let greet_config = default_greet_config();
+    let replay_config = ReplayConfig {
+        enable_auto_replay: false,
+        templates: Vec::new(),
+        enable_llm: false,
+        reply_prompt: None,
+        background_context: None,
+    };
+    let resume_config = ResumeConfig {
+        inject_llm_context: false,
+        resume_path: None,
+        resume_content: None,
+    };
+    let default_profile = JobProfile {
+        id: DEFAULT_JOB_PROFILE_ID.to_string(),
+        name: DEFAULT_JOB_PROFILE_NAME.to_string(),
+        description: None,
+        archived: false,
+        job_filter_config: job_filter_config.clone(),
+        platform_filter_config: platform_filter_config.clone(),
+        resume_config: resume_config.clone(),
+        greet_config: greet_config.clone(),
+        replay_config: replay_config.clone(),
+    };
+
     AppRuntimeConfig {
         schema_version: CURRENT_SCHEMA_VERSION,
         onboarding_completed: false,
         llm_config: None,
         llm_fallbacks: Vec::new(),
         llm_retry_config: LlmRetryConfig::default(),
-        job_filter_config: JobFilterConfig {
-            query: Some("Rust 工程师".to_string()),
-            city: None,
-            job_type: 0,
-            salary: 0,
-            experience: Vec::new(),
-            dgree: Vec::new(),
-            industry: Vec::new(),
-            scale: Vec::new(),
-            stage: Vec::new(),
-            keywords: Vec::new(),
-            exclude_keywords: Vec::new(),
-            company_keywords: Vec::new(),
-            company_exclude_keywords: Vec::new(),
-            enable_semantic_filter: false,
-            semantic_filter_intent: None,
-            regex_rules: Vec::new(),
-        },
-        platform_filter_config: PlatformFilterConfig::default(),
-        greet_config: default_greet_config(),
-        replay_config: ReplayConfig {
-            enable_auto_replay: false,
-            templates: Vec::new(),
-            enable_llm: false,
-            reply_prompt: None,
-            background_context: None,
-        },
+        job_profiles: vec![default_profile],
+        default_job_profile_id: DEFAULT_JOB_PROFILE_ID.to_string(),
+        active_job_profile: None,
+        job_filter_config,
+        platform_filter_config,
+        greet_config,
+        replay_config,
         browser_config: BrowserConfig {
             user_data_dir: "".to_string(),
             chrome_exe_path: None,
             max_parallel_tasks: default_max_parallel_tasks(),
         },
-        resume_config: ResumeConfig {
-            inject_llm_context: false,
-            resume_path: None,
-            resume_content: None,
-        },
+        resume_config,
     }
 }
 
@@ -260,6 +282,24 @@ pub(crate) fn parse_config_content(content: &str) -> Result<AppRuntimeConfig, St
         config.resume_config =
             serde_yaml::from_value(resume_config.clone()).map_err(|error| error.to_string())?;
     }
+    if let Some(job_profiles) = value.get("job_profiles") {
+        config.job_profiles =
+            serde_yaml::from_value(job_profiles.clone()).map_err(|error| error.to_string())?;
+    } else {
+        // v0-v2 的五块求职配置就是唯一的求职方案。迁移时完整复制，避免升级丢失
+        // 平台筛选、简历或话术；之后仍保留顶层字段作为旧调用方的执行镜像。
+        config.job_profiles = vec![JobProfile::from_runtime_mirror(
+            DEFAULT_JOB_PROFILE_ID,
+            DEFAULT_JOB_PROFILE_NAME,
+            &config,
+        )];
+    }
+    config.default_job_profile_id = value
+        .get("default_job_profile_id")
+        .map(|profile_id| serde_yaml::from_value(profile_id.clone()))
+        .transpose()
+        .map_err(|error| error.to_string())?
+        .unwrap_or_else(|| DEFAULT_JOB_PROFILE_ID.to_string());
 
     validate_and_normalize(&mut config)?;
     Ok(config)
@@ -347,7 +387,7 @@ pub fn validate_and_normalize(config: &mut AppRuntimeConfig) -> Result<(), Strin
 
     normalize_llm_retry_config(&mut config.llm_retry_config);
     normalize_llm_fallbacks(&mut config.llm_fallbacks)?;
-    validate_greet_template(&config.greet_config)?;
+    normalize_job_profiles(config)?;
     config.browser_config.max_parallel_tasks = config
         .browser_config
         .max_parallel_tasks
@@ -527,6 +567,18 @@ pub struct AppRuntimeConfig {
     #[serde(default)]
     pub llm_retry_config: LlmRetryConfig,
 
+    /// 可复用的求职方案卡。方案卡是持久化主数据，顶层五块配置仅作为默认方案的兼容镜像。
+    #[serde(default)]
+    pub job_profiles: Vec<JobProfile>,
+
+    /// 未显式选择方案时使用的方案标识
+    #[serde(default = "default_job_profile_id")]
+    pub default_job_profile_id: String,
+
+    /// 队列执行快照所绑定的方案元信息，不写入配置文件。
+    #[serde(skip)]
+    pub active_job_profile: Option<ActiveJobProfile>,
+
     /// 岗位筛选配置
     pub job_filter_config: JobFilterConfig,
 
@@ -545,6 +597,119 @@ pub struct AppRuntimeConfig {
 
     /// 简历配置
     pub resume_config: ResumeConfig,
+}
+
+fn default_job_profile_id() -> String {
+    DEFAULT_JOB_PROFILE_ID.to_string()
+}
+
+/// 一张完整、可独立执行的求职方案卡。
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct JobProfile {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub archived: bool,
+    pub job_filter_config: JobFilterConfig,
+    #[serde(default)]
+    pub platform_filter_config: PlatformFilterConfig,
+    pub resume_config: ResumeConfig,
+    pub greet_config: GreetConfig,
+    pub replay_config: ReplayConfig,
+}
+
+impl JobProfile {
+    fn from_runtime_mirror(id: &str, name: &str, config: &AppRuntimeConfig) -> Self {
+        Self {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: None,
+            archived: false,
+            job_filter_config: config.job_filter_config.clone(),
+            platform_filter_config: config.platform_filter_config.clone(),
+            resume_config: config.resume_config.clone(),
+            greet_config: config.greet_config.clone(),
+            replay_config: config.replay_config.clone(),
+        }
+    }
+}
+
+/// 运行中的配置快照实际绑定到哪张方案卡。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveJobProfile {
+    pub id: String,
+    pub name: String,
+    pub snapshot_id: String,
+}
+
+/// 方案解析结果：既提供旧 RPA 可直接消费的扁平配置，也提供队列持久化所需元信息。
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedJobProfile {
+    pub config: AppRuntimeConfig,
+    pub profile_id: String,
+    pub profile_name: String,
+    pub snapshot_id: String,
+}
+
+/// 将选中方案解析为旧执行层所需的扁平配置快照。
+/// `profile_id` 为空时解析默认方案；归档方案不能用于创建新任务。
+pub fn resolve_job_profile(
+    config: &AppRuntimeConfig,
+    profile_id: Option<&str>,
+) -> Result<ResolvedJobProfile, String> {
+    let mut snapshot = config.clone();
+    validate_and_normalize(&mut snapshot)?;
+    let profile = snapshot.job_profile(profile_id)?.clone();
+    if profile.archived {
+        return Err(format!(
+            "求职方案「{}」已归档，不能用于新任务",
+            profile.name
+        ));
+    }
+
+    let snapshot_id = job_profile_snapshot_id(&profile)?;
+    let active = ActiveJobProfile {
+        id: profile.id.clone(),
+        name: profile.name.clone(),
+        snapshot_id: snapshot_id.clone(),
+    };
+    snapshot.job_filter_config = profile.job_filter_config;
+    snapshot.platform_filter_config = profile.platform_filter_config;
+    snapshot.resume_config = profile.resume_config;
+    snapshot.greet_config = profile.greet_config;
+    snapshot.replay_config = profile.replay_config;
+    snapshot.active_job_profile = Some(active);
+
+    Ok(ResolvedJobProfile {
+        config: snapshot,
+        profile_id: profile.id,
+        profile_name: profile.name,
+        snapshot_id,
+    })
+}
+
+fn job_profile_snapshot_id(profile: &JobProfile) -> Result<String, String> {
+    // 对稳定方案身份和实际执行内容做指纹。重命名或说明调整不会产生新版本；
+    // 但两张不同方案即使内容暂时相同也必须保持快照身份隔离，否则后保存的
+    // 方案元数据会覆盖前一张卡的历史归属。
+    let bytes = serde_json::to_vec(&(
+        &profile.id,
+        &profile.job_filter_config,
+        &profile.platform_filter_config,
+        &profile.resume_config,
+        &profile.greet_config,
+        &profile.replay_config,
+    ))
+    .map_err(|error| error.to_string())?;
+    // FNV-1a 是跨进程、跨平台确定的内容指纹；这里只用于识别相同执行内容，不承担安全用途。
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    Ok(format!("jp-{hash:016x}"))
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -667,6 +832,18 @@ impl LlmChainLink {
 }
 
 impl AppRuntimeConfig {
+    /// 按稳定标识查找方案；未传标识时使用默认方案。
+    pub fn job_profile(&self, profile_id: Option<&str>) -> Result<&JobProfile, String> {
+        let profile_id = profile_id
+            .map(str::trim)
+            .filter(|profile_id| !profile_id.is_empty())
+            .unwrap_or(self.default_job_profile_id.as_str());
+        self.job_profiles
+            .iter()
+            .find(|profile| profile.id == profile_id)
+            .ok_or_else(|| format!("求职方案不存在：{profile_id}"))
+    }
+
     /// 按调用顺序返回大模型降级链：主用服务在前，其后是处于启用状态的备用服务。
     /// 未配置主用服务时返回空链，调用方据此报「请先配置大模型服务」。
     pub fn llm_chain(&self) -> Vec<LlmChainLink> {
@@ -1002,6 +1179,68 @@ pub struct BrowserConfig {
     /// 同时执行的自动化任务上限。当前仅开放跨平台双任务并行。
     #[serde(default = "default_max_parallel_tasks")]
     pub max_parallel_tasks: usize,
+}
+
+fn normalize_job_profiles(config: &mut AppRuntimeConfig) -> Result<(), String> {
+    // 备份导入等旧路径可能直接把 v0-v2 YAML 反序列化为 AppRuntimeConfig，绕过
+    // parse_config_content。这里补上同等迁移；v3 显式保存空列表仍按无效配置拒绝。
+    if config.job_profiles.is_empty() && config.schema_version < 3 {
+        config.job_profiles = vec![JobProfile::from_runtime_mirror(
+            DEFAULT_JOB_PROFILE_ID,
+            DEFAULT_JOB_PROFILE_NAME,
+            config,
+        )];
+        config.default_job_profile_id = DEFAULT_JOB_PROFILE_ID.to_string();
+    }
+
+    let mut ids = HashSet::new();
+    let mut active_count = 0usize;
+
+    for profile in &mut config.job_profiles {
+        profile.id = profile.id.trim().to_string();
+        profile.name = profile.name.trim().to_string();
+        profile.description = profile
+            .description
+            .take()
+            .map(|description| description.trim().to_string())
+            .filter(|description| !description.is_empty());
+
+        if profile.id.is_empty() {
+            return Err("求职方案标识不能为空".to_string());
+        }
+        if profile.name.is_empty() {
+            return Err(format!("求职方案 {} 的名称不能为空", profile.id));
+        }
+        if !ids.insert(profile.id.clone()) {
+            return Err(format!("求职方案标识重复：{}", profile.id));
+        }
+        if !profile.archived {
+            active_count += 1;
+        }
+        validate_greet_template(&profile.greet_config)
+            .map_err(|error| format!("求职方案「{}」无效：{error}", profile.name))?;
+    }
+
+    if active_count == 0 {
+        return Err("至少需要保留一张未归档的求职方案".to_string());
+    }
+
+    config.default_job_profile_id = config.default_job_profile_id.trim().to_string();
+    let default_profile = config
+        .job_profiles
+        .iter()
+        .find(|profile| profile.id == config.default_job_profile_id)
+        .ok_or_else(|| "默认求职方案不存在".to_string())?;
+    if default_profile.archived {
+        return Err("默认求职方案不能是已归档方案".to_string());
+    }
+
+    config.job_filter_config = default_profile.job_filter_config.clone();
+    config.platform_filter_config = default_profile.platform_filter_config.clone();
+    config.resume_config = default_profile.resume_config.clone();
+    config.greet_config = default_profile.greet_config.clone();
+    config.replay_config = default_profile.replay_config.clone();
+    Ok(())
 }
 
 fn default_max_parallel_tasks() -> usize {
@@ -1405,13 +1644,270 @@ greet_config:
     #[test]
     fn multiple_llm_items_are_rejected() {
         let mut config = default_app_config();
-        config.greet_config.default_template = vec![
+        config.job_profiles[0].greet_config.default_template = vec![
             GreetResource::new(ReplayResourceType::LLM, String::new()),
             GreetResource::new(ReplayResourceType::LLM, String::new()),
         ];
 
         let error = validate_and_normalize(&mut config).unwrap_err();
         assert!(error.contains("最多只能包含一条 LLM"));
+    }
+
+    #[test]
+    fn v2_flat_config_is_migrated_losslessly_to_default_profile() {
+        let config = parse_config_content(
+            r#"
+schema_version: 2
+job_filter_config:
+  query: AI 应用工程师
+  city: 101020100
+  job_type: 1901
+  salary: 405
+  experience: [103]
+  dgree: [203]
+  industry: []
+  scale: []
+  stage: []
+  keywords: [Agent]
+  exclude_keywords: [外包]
+  company_keywords: []
+  company_exclude_keywords: []
+  enable_semantic_filter: true
+  semantic_filter_intent: "AI Agent 应用开发"
+  regex_rules: []
+platform_filter_config:
+  liepin:
+    dq: "020"
+    salary_code: "40$60"
+    pub_time: "3"
+    work_year_code: "1$3"
+    comp_tag: ["104"]
+greet_config:
+  enable_llm: false
+  reply_prompt: null
+  default_template:
+    - resource_type: Text
+      content: "您好"
+replay_config:
+  enable_auto_replay: false
+  templates: []
+  enable_llm: false
+  reply_prompt: null
+  background_context: "可立即到岗"
+browser_config:
+  user_data_dir: profile
+  chrome_exe_path: null
+resume_config:
+  inject_llm_context: true
+  resume_path: resume.pdf
+  resume_content: "Agent 项目经验"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.job_profiles.len(), 1);
+        assert_eq!(config.default_job_profile_id, DEFAULT_JOB_PROFILE_ID);
+        let profile = &config.job_profiles[0];
+        assert_eq!(profile.name, DEFAULT_JOB_PROFILE_NAME);
+        assert_eq!(
+            profile.job_filter_config.query.as_deref(),
+            Some("AI 应用工程师")
+        );
+        assert_eq!(
+            profile.platform_filter_config.liepin.dq.as_deref(),
+            Some("020")
+        );
+        assert_eq!(
+            profile.resume_config.resume_content.as_deref(),
+            Some("Agent 项目经验")
+        );
+        assert_eq!(profile.greet_config.default_template[0].content, "您好");
+        assert_eq!(
+            profile.replay_config.background_context.as_deref(),
+            Some("可立即到岗")
+        );
+    }
+
+    #[test]
+    fn job_profile_validation_rejects_invalid_collections_and_default() {
+        let mut config = default_app_config();
+        config.job_profiles[0].name = "   ".to_string();
+        assert!(validate_and_normalize(&mut config)
+            .unwrap_err()
+            .contains("名称不能为空"));
+
+        let mut config = default_app_config();
+        config.job_profiles.push(config.job_profiles[0].clone());
+        assert!(validate_and_normalize(&mut config)
+            .unwrap_err()
+            .contains("标识重复"));
+
+        let mut config = default_app_config();
+        config.default_job_profile_id = "missing".to_string();
+        assert!(validate_and_normalize(&mut config)
+            .unwrap_err()
+            .contains("默认求职方案不存在"));
+
+        let mut config = default_app_config();
+        config.job_profiles[0].archived = true;
+        assert!(validate_and_normalize(&mut config)
+            .unwrap_err()
+            .contains("至少需要保留"));
+
+        let mut config = default_app_config();
+        let mut available = config.job_profiles[0].clone();
+        available.id = "available".to_string();
+        config.job_profiles.push(available);
+        config.job_profiles[0].archived = true;
+        assert!(validate_and_normalize(&mut config)
+            .unwrap_err()
+            .contains("默认求职方案不能是已归档"));
+    }
+
+    #[test]
+    fn v3_explicit_empty_profile_collection_is_rejected() {
+        let error = parse_config_content(
+            r#"
+schema_version: 3
+default_job_profile_id: default
+job_profiles: []
+"#,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("至少需要保留"));
+    }
+
+    #[test]
+    fn direct_v2_deserialization_is_migrated_during_normalization() {
+        let serialized = serde_yaml::to_string(&default_app_config()).unwrap();
+        let mut value: serde_yaml::Value = serde_yaml::from_str(&serialized).unwrap();
+        let mapping = value.as_mapping_mut().unwrap();
+        mapping.remove(serde_yaml::Value::String("job_profiles".to_string()));
+        mapping.remove(serde_yaml::Value::String(
+            "default_job_profile_id".to_string(),
+        ));
+        mapping.insert(
+            serde_yaml::Value::String("schema_version".to_string()),
+            serde_yaml::Value::Number(2.into()),
+        );
+        let legacy = serde_yaml::to_string(&value).unwrap();
+        let mut config: AppRuntimeConfig = serde_yaml::from_str(&legacy).unwrap();
+
+        validate_and_normalize(&mut config).unwrap();
+
+        assert_eq!(config.job_profiles.len(), 1);
+        assert_eq!(config.job_profiles[0].id, DEFAULT_JOB_PROFILE_ID);
+        assert_eq!(
+            config.job_profiles[0].job_filter_config,
+            config.job_filter_config
+        );
+    }
+
+    #[test]
+    fn profile_config_round_trip_preserves_cards_and_default_mirror() {
+        let mut config = default_app_config();
+        let mut second = config.job_profiles[0].clone();
+        second.id = "rust-backend".to_string();
+        second.name = "Rust 后端".to_string();
+        second.description = Some("  高并发服务端方向  ".to_string());
+        second.job_filter_config.query = Some("Rust 后端工程师".to_string());
+        config.job_profiles.push(second);
+        config.default_job_profile_id = "rust-backend".to_string();
+        validate_and_normalize(&mut config).unwrap();
+
+        let serialized = serde_yaml::to_string(&config).unwrap();
+        let restored = parse_config_content(&serialized).unwrap();
+
+        assert_eq!(restored.job_profiles.len(), 2);
+        assert_eq!(restored.default_job_profile_id, "rust-backend");
+        assert_eq!(
+            restored.job_profiles[1].description.as_deref(),
+            Some("高并发服务端方向")
+        );
+        assert_eq!(
+            restored.job_filter_config.query.as_deref(),
+            Some("Rust 后端工程师")
+        );
+        assert_eq!(restored.active_job_profile, None);
+    }
+
+    #[test]
+    fn normalization_mirrors_default_profile_into_flat_config() {
+        let mut config = default_app_config();
+        config.job_profiles[0].job_filter_config.query = Some("后端工程师".to_string());
+        config.job_profiles[0].resume_config.resume_content = Some("Rust 项目".to_string());
+        config.job_filter_config.query = Some("过期镜像".to_string());
+
+        validate_and_normalize(&mut config).unwrap();
+
+        assert_eq!(
+            config.job_filter_config.query.as_deref(),
+            Some("后端工程师")
+        );
+        assert_eq!(
+            config.resume_config.resume_content.as_deref(),
+            Some("Rust 项目")
+        );
+    }
+
+    #[test]
+    fn resolve_job_profile_builds_flat_immutable_execution_snapshot() {
+        let mut config = default_app_config();
+        let mut ai_profile = config.job_profiles[0].clone();
+        ai_profile.id = "ai-agent".to_string();
+        ai_profile.name = "AI Agent".to_string();
+        ai_profile.job_filter_config.query = Some("AI Agent 工程师".to_string());
+        ai_profile.resume_config.resume_content = Some("定向简历".to_string());
+        config.job_profiles.push(ai_profile);
+
+        let resolved = resolve_job_profile(&config, Some("ai-agent")).unwrap();
+
+        assert_eq!(resolved.profile_id, "ai-agent");
+        assert_eq!(resolved.profile_name, "AI Agent");
+        assert!(resolved.snapshot_id.starts_with("jp-"));
+        assert_eq!(
+            resolved.config.job_filter_config.query.as_deref(),
+            Some("AI Agent 工程师")
+        );
+        assert_eq!(
+            resolved.config.resume_config.resume_content.as_deref(),
+            Some("定向简历")
+        );
+        assert_eq!(
+            resolved.config.active_job_profile.as_ref().unwrap().id,
+            "ai-agent"
+        );
+        assert!(!serde_yaml::to_string(&resolved.config)
+            .unwrap()
+            .contains("active_job_profile"));
+
+        // 后续编辑原方案不会污染已经解析完成的队列快照。
+        config.job_profiles[1].resume_config.resume_content = Some("新版简历".to_string());
+        assert_eq!(
+            resolved.config.resume_config.resume_content.as_deref(),
+            Some("定向简历")
+        );
+    }
+
+    #[test]
+    fn snapshot_id_tracks_execution_content_but_not_profile_label() {
+        let config = default_app_config();
+        let first = resolve_job_profile(&config, None).unwrap();
+        let mut renamed = config.clone();
+        renamed.job_profiles[0].name = "重命名方案".to_string();
+        let second = resolve_job_profile(&renamed, None).unwrap();
+        assert_eq!(first.snapshot_id, second.snapshot_id);
+
+        renamed.job_profiles[0].job_filter_config.query = Some("Java".to_string());
+        let changed = resolve_job_profile(&renamed, None).unwrap();
+        assert_ne!(first.snapshot_id, changed.snapshot_id);
+
+        let mut copied = config.clone();
+        copied.job_profiles[0].id = "copied-profile".to_string();
+        copied.default_job_profile_id = "copied-profile".to_string();
+        let copied = resolve_job_profile(&copied, None).unwrap();
+        assert_ne!(first.snapshot_id, copied.snapshot_id);
     }
 
     fn fallback_entry(id: &str, model: &str) -> LlmProviderEntry {

--- a/src-tauri/src/credential.rs
+++ b/src-tauri/src/credential.rs
@@ -295,8 +295,10 @@ mod entry_tests {
 
     #[test]
     fn environment_fallback_only_applies_to_the_primary_entry() {
-        assert!(KeyringCredentialBackend::for_entry(PRIMARY_LLM_ENTRY_ID)
-            == KeyringCredentialBackend::default());
+        assert!(
+            KeyringCredentialBackend::for_entry(PRIMARY_LLM_ENTRY_ID)
+                == KeyringCredentialBackend::default()
+        );
         assert_ne!(
             KeyringCredentialBackend::for_entry("backup-a"),
             KeyringCredentialBackend::default()

--- a/src-tauri/src/dao/chat_message_dao.rs
+++ b/src-tauri/src/dao/chat_message_dao.rs
@@ -42,47 +42,46 @@ pub struct ChatMessageSaveResult {
 
 /// 按 job_id + mid 增量写入；已存在的消息内容发生变化时同步更新。
 pub fn upsert_incremental(job_id: &str, messages: &[ChatMessage]) -> Result<ChatMessageSaveResult> {
-    let mut all = store().load_all()?;
-    let mut indexes: HashMap<i64, usize> = all
-        .iter()
-        .enumerate()
-        .filter(|(_, record)| record.job_id == job_id)
-        .map(|(index, record)| (record.mid, index))
-        .collect();
-    let mut result = ChatMessageSaveResult::default();
+    store().transaction(|all| {
+        let mut indexes: HashMap<i64, usize> = all
+            .iter()
+            .enumerate()
+            .filter(|(_, record)| record.job_id == job_id)
+            .map(|(index, record)| (record.mid, index))
+            .collect();
+        let mut result = ChatMessageSaveResult::default();
 
-    for msg in messages {
-        let record = ChatMessageRecord {
-            id: format!("{}:{}", job_id, msg.mid),
-            job_id: job_id.to_string(),
-            mid: msg.mid,
-            received: msg.received,
-            text: msg.text.clone(),
-            time: msg.time,
-            from_name: msg.from_name.clone(),
-        };
+        for msg in messages {
+            let record = ChatMessageRecord {
+                id: format!("{}:{}", job_id, msg.mid),
+                job_id: job_id.to_string(),
+                mid: msg.mid,
+                received: msg.received,
+                text: msg.text.clone(),
+                time: msg.time,
+                from_name: msg.from_name.clone(),
+            };
 
-        if let Some(index) = indexes.get(&msg.mid).copied() {
-            let existing = &all[index];
-            if existing.received != record.received
-                || existing.text != record.text
-                || existing.time != record.time
-                || existing.from_name != record.from_name
-            {
-                all[index] = record;
-                result.updated += 1;
+            if let Some(index) = indexes.get(&msg.mid).copied() {
+                let existing = &all[index];
+                if existing.received != record.received
+                    || existing.text != record.text
+                    || existing.time != record.time
+                    || existing.from_name != record.from_name
+                {
+                    all[index] = record;
+                    result.updated += 1;
+                }
+            } else {
+                indexes.insert(msg.mid, all.len());
+                all.push(record);
+                result.inserted += 1;
             }
-        } else {
-            indexes.insert(msg.mid, all.len());
-            all.push(record);
-            result.inserted += 1;
         }
-    }
 
-    if result.inserted > 0 || result.updated > 0 {
-        store().replace_all(all)?;
-    }
-    Ok(result)
+        let changed = result.inserted > 0 || result.updated > 0;
+        Ok((result, changed))
+    })
 }
 
 /// 兼容既有调用方，只返回新增条数。
@@ -91,15 +90,12 @@ pub fn save_incremental(job_id: &str, messages: &[ChatMessage]) -> Result<usize>
 }
 
 pub fn delete_by_job_id(job_id: &str) -> Result<bool> {
-    let existing = find_by_job_id(job_id)?;
-    if existing.is_empty() {
-        return Ok(false);
-    }
-    let all = store().load_all()?;
-    let remaining: Vec<ChatMessageRecord> =
-        all.into_iter().filter(|m| m.job_id != job_id).collect();
-    store().replace_all(remaining)?;
-    Ok(true)
+    store().transaction(|all| {
+        let original_len = all.len();
+        all.retain(|message| message.job_id != job_id);
+        let changed = all.len() < original_len;
+        Ok((changed, changed))
+    })
 }
 
 pub fn batch_insert_new(items: Vec<ChatMessageRecord>) -> Result<usize> {

--- a/src-tauri/src/dao/job_detail_dao.rs
+++ b/src-tauri/src/dao/job_detail_dao.rs
@@ -26,6 +26,25 @@ pub fn get_by_id(id: &str) -> Result<Option<JobDetail>> {
     store().get_by_id(id)
 }
 
+/// 平台侧有时会给出带/不带平台前缀的岗位标识，按两种形式查找归属。
+pub fn find_by_platform_job_id(platform: &str, id: &str) -> Result<Option<JobDetail>> {
+    if let Some(job) = get_by_id(id)? {
+        return Ok(Some(job));
+    }
+    let prefixed = format!("{platform}:{id}");
+    if let Some(job) = get_by_id(&prefixed)? {
+        return Ok(Some(job));
+    }
+    Ok(list()?.into_iter().find(|job| {
+        job.platform.eq_ignore_ascii_case(platform)
+            && job
+                .id
+                .strip_prefix(&format!("{platform}:"))
+                .unwrap_or(&job.id)
+                == id
+    }))
+}
+
 pub fn create(job: JobDetail) -> Result<()> {
     store().insert(job)
 }

--- a/src-tauri/src/dao/mod.rs
+++ b/src-tauri/src/dao/mod.rs
@@ -2,6 +2,7 @@ pub mod analysis_dao;
 pub mod chat_message_dao;
 pub mod job_detail_dao;
 pub mod model;
+pub mod profile_snapshot_dao;
 pub mod store;
 
 use anyhow::Result;
@@ -11,5 +12,6 @@ pub fn init(data_dir: &Path) -> Result<()> {
     job_detail_dao::init(data_dir)?;
     analysis_dao::init(data_dir)?;
     chat_message_dao::init(data_dir)?;
+    profile_snapshot_dao::init(data_dir)?;
     Ok(())
 }

--- a/src-tauri/src/dao/model.rs
+++ b/src-tauri/src/dao/model.rs
@@ -1,5 +1,56 @@
 use serde::{Deserialize, Serialize};
 
+use crate::config::{
+    AppRuntimeConfig, GreetConfig, JobFilterConfig, PlatformFilterConfig, ReplayConfig,
+    ResumeConfig,
+};
+
+/// 一次求职任务实际使用的不可变方案内容。
+///
+/// 这里只保存方案拥有的五块策略，不复制浏览器、模型提供商等全局配置。
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct JobProfileSnapshot {
+    pub snapshot_id: String,
+    pub profile_id: String,
+    pub profile_name: String,
+    pub job_filter_config: JobFilterConfig,
+    pub platform_filter_config: PlatformFilterConfig,
+    pub greet_config: GreetConfig,
+    pub replay_config: ReplayConfig,
+    pub resume_config: ResumeConfig,
+}
+
+impl JobProfileSnapshot {
+    pub fn from_resolved(config: &AppRuntimeConfig) -> Option<Self> {
+        let active = config.active_job_profile.as_ref()?;
+        Some(Self {
+            snapshot_id: active.snapshot_id.clone(),
+            profile_id: active.id.clone(),
+            profile_name: active.name.clone(),
+            job_filter_config: config.job_filter_config.clone(),
+            platform_filter_config: config.platform_filter_config.clone(),
+            greet_config: config.greet_config.clone(),
+            replay_config: config.replay_config.clone(),
+            resume_config: config.resume_config.clone(),
+        })
+    }
+
+    pub fn apply_to(&self, base: &AppRuntimeConfig) -> AppRuntimeConfig {
+        let mut config = base.clone();
+        config.job_filter_config = self.job_filter_config.clone();
+        config.platform_filter_config = self.platform_filter_config.clone();
+        config.greet_config = self.greet_config.clone();
+        config.replay_config = self.replay_config.clone();
+        config.resume_config = self.resume_config.clone();
+        config.active_job_profile = Some(crate::config::ActiveJobProfile {
+            id: self.profile_id.clone(),
+            name: self.profile_name.clone(),
+            snapshot_id: self.snapshot_id.clone(),
+        });
+        config
+    }
+}
+
 /// 岗位详情表
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct JobDetail {
@@ -9,6 +60,22 @@ pub struct JobDetail {
     /// 岗位来源平台: boss / liepin
     #[serde(default)]
     pub platform: String,
+
+    /// 首次建联任务。旧数据没有该字段时保持为空。
+    #[serde(default)]
+    pub source_task_id: Option<String>,
+
+    /// 首次建联使用的求职方案。
+    #[serde(default)]
+    pub profile_id: Option<String>,
+
+    /// 冗余保存方案名称，便于历史任务和岗位直接展示。
+    #[serde(default)]
+    pub profile_name: Option<String>,
+
+    /// 首次建联时不可变方案快照的标识。
+    #[serde(default)]
+    pub profile_snapshot_id: Option<String>,
 
     /// 岗位标题
     pub title: String,
@@ -148,4 +215,34 @@ pub struct ChatMessageRecord {
     /// 发送时间戳（毫秒）
     pub time: i64,
     pub from_name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{default_app_config, resolve_job_profile};
+
+    #[test]
+    fn snapshot_restores_original_profile_strategy_after_base_changes() {
+        let base = default_app_config();
+        let resolved = resolve_job_profile(&base, None).unwrap();
+        let snapshot = JobProfileSnapshot::from_resolved(&resolved.config).unwrap();
+        let original_query = snapshot.job_filter_config.query.clone();
+        let original_prompt = snapshot.greet_config.reply_prompt.clone();
+
+        let mut edited = base;
+        edited.job_filter_config.query = Some("完全不同的岗位".into());
+        edited.greet_config.reply_prompt = Some("已经修改的新提示词".into());
+        let restored = snapshot.apply_to(&edited);
+
+        assert_eq!(restored.job_filter_config.query, original_query);
+        assert_eq!(restored.greet_config.reply_prompt, original_prompt);
+        assert_eq!(
+            restored
+                .active_job_profile
+                .as_ref()
+                .map(|value| value.snapshot_id.as_str()),
+            Some(snapshot.snapshot_id.as_str())
+        );
+    }
 }

--- a/src-tauri/src/dao/profile_snapshot_dao.rs
+++ b/src-tauri/src/dao/profile_snapshot_dao.rs
@@ -1,0 +1,156 @@
+use std::{path::Path, sync::OnceLock};
+
+use crate::dao::store::BatchResult;
+use anyhow::Result;
+
+use crate::{
+    config::{resolve_job_profile, AppRuntimeConfig},
+    dao::{
+        model::{JobDetail, JobProfileSnapshot},
+        store::JsonStore,
+    },
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolutionSource {
+    Snapshot,
+    CurrentProfile,
+    DefaultProfile,
+}
+
+static STORE: OnceLock<JsonStore<JobProfileSnapshot>> = OnceLock::new();
+
+pub fn init(data_dir: &Path) -> Result<()> {
+    STORE
+        .set(JsonStore::new(data_dir, "job_profile_snapshots.json")?)
+        .map_err(|_| anyhow::anyhow!("JobProfileSnapshotDao 已经初始化"))
+}
+
+fn store() -> &'static JsonStore<JobProfileSnapshot> {
+    STORE.get().expect("JobProfileSnapshotDao 未初始化")
+}
+
+pub fn get_by_id(snapshot_id: &str) -> Result<Option<JobProfileSnapshot>> {
+    store().get_by_id(snapshot_id)
+}
+
+pub fn list() -> Result<Vec<JobProfileSnapshot>> {
+    store().load_all()
+}
+
+pub fn replace_all(items: Vec<JobProfileSnapshot>) -> Result<()> {
+    store().replace_all(items)
+}
+
+pub fn batch_upsert(items: Vec<JobProfileSnapshot>) -> Result<BatchResult> {
+    store().batch_upsert(items, |existing, incoming| existing != incoming)
+}
+
+/// 内容哈希相同的快照只保存一次。
+pub fn upsert(snapshot: JobProfileSnapshot) -> Result<()> {
+    store().batch_upsert(vec![snapshot], |existing, incoming| existing != incoming)?;
+    Ok(())
+}
+
+/// 恢复历史会话首次建联时的策略。快照是首选；升级前的数据或已损坏的引用才回退。
+pub fn resolve_for_job(
+    base: &AppRuntimeConfig,
+    job: Option<&JobDetail>,
+) -> Result<(AppRuntimeConfig, ResolutionSource), String> {
+    let snapshot = match job.and_then(|job| job.profile_snapshot_id.as_deref()) {
+        Some(snapshot_id) => get_by_id(snapshot_id).map_err(|error| error.to_string())?,
+        None => None,
+    };
+    resolve_from_sources(base, job, snapshot.as_ref())
+}
+
+fn resolve_from_sources(
+    base: &AppRuntimeConfig,
+    job: Option<&JobDetail>,
+    snapshot: Option<&JobProfileSnapshot>,
+) -> Result<(AppRuntimeConfig, ResolutionSource), String> {
+    if let Some(snapshot) = snapshot {
+        return Ok((snapshot.apply_to(base), ResolutionSource::Snapshot));
+    }
+    if let Some(profile_id) = job.and_then(|job| job.profile_id.as_deref()) {
+        // 历史会话允许继续使用后来已归档的同名方案；归档只阻止创建新投递任务。
+        if let Some(profile) = base
+            .job_profiles
+            .iter()
+            .find(|profile| profile.id == profile_id)
+        {
+            let mut config = base.clone();
+            config.job_filter_config = profile.job_filter_config.clone();
+            config.platform_filter_config = profile.platform_filter_config.clone();
+            config.resume_config = profile.resume_config.clone();
+            config.greet_config = profile.greet_config.clone();
+            config.replay_config = profile.replay_config.clone();
+            config.active_job_profile = None;
+            return Ok((config, ResolutionSource::CurrentProfile));
+        }
+    }
+
+    resolve_job_profile(base, None)
+        .map(|resolved| (resolved.config, ResolutionSource::DefaultProfile))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{default_app_config, resolve_job_profile};
+
+    fn legacy_job(profile_id: Option<&str>) -> JobDetail {
+        JobDetail {
+            id: "job".into(),
+            platform: "boss".into(),
+            source_task_id: None,
+            profile_id: profile_id.map(str::to_string),
+            profile_name: None,
+            profile_snapshot_id: None,
+            title: String::new(),
+            company_name: String::new(),
+            detail: String::new(),
+            salary: String::new(),
+            location: None,
+            is_reply: false,
+            is_send_resume: false,
+            created_at: String::new(),
+            resume_sent_at: None,
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn persisted_snapshot_has_priority_over_current_profile() {
+        let mut base = default_app_config();
+        let resolved = resolve_job_profile(&base, None).unwrap();
+        let snapshot = JobProfileSnapshot::from_resolved(&resolved.config).unwrap();
+        let old_query = snapshot.job_filter_config.query.clone();
+        base.job_profiles[0].job_filter_config.query = Some("后来编辑的方向".into());
+
+        let (config, source) = resolve_from_sources(
+            &base,
+            Some(&legacy_job(Some(&snapshot.profile_id))),
+            Some(&snapshot),
+        )
+        .unwrap();
+
+        assert_eq!(source, ResolutionSource::Snapshot);
+        assert_eq!(config.job_filter_config.query, old_query);
+    }
+
+    #[test]
+    fn old_job_without_profile_falls_back_to_default() {
+        let base = default_app_config();
+        let (config, source) = resolve_from_sources(&base, Some(&legacy_job(None)), None).unwrap();
+
+        assert_eq!(source, ResolutionSource::DefaultProfile);
+        assert_eq!(
+            config
+                .active_job_profile
+                .as_ref()
+                .map(|profile| profile.id.as_str()),
+            Some(base.default_job_profile_id.as_str())
+        );
+    }
+}

--- a/src-tauri/src/dao/store.rs
+++ b/src-tauri/src/dao/store.rs
@@ -1,4 +1,4 @@
-use crate::dao::model::{ChatMessageRecord, InterviewJobAnalysis, JobDetail};
+use crate::dao::model::{ChatMessageRecord, InterviewJobAnalysis, JobDetail, JobProfileSnapshot};
 use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -35,6 +35,12 @@ impl Identifiable for InterviewJobAnalysis {
 impl Identifiable for ChatMessageRecord {
     fn id(&self) -> &str {
         &self.id
+    }
+}
+
+impl Identifiable for JobProfileSnapshot {
+    fn id(&self) -> &str {
+        &self.snapshot_id
     }
 }
 

--- a/src-tauri/src/dao/store.rs
+++ b/src-tauri/src/dao/store.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 /// 批量操作结果
 #[derive(Debug, Default, Clone, Copy)]
@@ -40,6 +41,9 @@ impl Identifiable for ChatMessageRecord {
 /// 通用 JSON 文件存储引擎
 pub struct JsonStore<T> {
     file_path: PathBuf,
+    /// Serializes a complete read-modify-write transaction for this store.
+    /// Read-only operations intentionally do not take this lock.
+    mutation_lock: Mutex<()>,
     _phantom: PhantomData<T>,
 }
 
@@ -51,12 +55,17 @@ impl<T: Serialize + DeserializeOwned + Identifiable> JsonStore<T> {
         fs::create_dir_all(&dir).with_context(|| format!("创建数据目录失败: {}", dir.display()))?;
         Ok(Self {
             file_path: dir.join(file_name),
+            mutation_lock: Mutex::new(()),
             _phantom: PhantomData,
         })
     }
 
     /// 读取全部数据
     pub fn load_all(&self) -> Result<Vec<T>> {
+        self.load_all_unlocked()
+    }
+
+    fn load_all_unlocked(&self) -> Result<Vec<T>> {
         if !self.file_path.exists() {
             return Ok(Vec::new());
         }
@@ -68,7 +77,7 @@ impl<T: Serialize + DeserializeOwned + Identifiable> JsonStore<T> {
     }
 
     /// 写入全部数据
-    fn save_all(&self, items: &[T]) -> Result<()> {
+    fn save_all_unlocked(&self, items: &[T]) -> Result<()> {
         let _permit = crate::storage::read_lock();
         let content = serde_json::to_string_pretty(items).with_context(|| "序列化数据失败")?;
         crate::storage::atomic::atomic_write(&self.file_path, content.as_bytes())
@@ -78,9 +87,10 @@ impl<T: Serialize + DeserializeOwned + Identifiable> JsonStore<T> {
 
     /// 新增一条记录
     pub fn insert(&self, item: T) -> Result<()> {
-        let mut items = self.load_all()?;
-        items.push(item);
-        self.save_all(&items)
+        self.transaction(|items| {
+            items.push(item);
+            Ok(((), true))
+        })
     }
 
     /// 按 ID 查询
@@ -91,29 +101,25 @@ impl<T: Serialize + DeserializeOwned + Identifiable> JsonStore<T> {
 
     /// 更新指定 ID 的记录
     pub fn update_by_id(&self, id: &str, updated: T) -> Result<bool> {
-        let mut items = self.load_all()?;
-        let index = items.iter().position(|item| item.id() == id);
-        match index {
-            Some(i) => {
-                items[i] = updated;
-                self.save_all(&items)?;
-                Ok(true)
-            }
-            None => Ok(false),
-        }
+        self.transaction(
+            |items| match items.iter().position(|item| item.id() == id) {
+                Some(i) => {
+                    items[i] = updated;
+                    Ok((true, true))
+                }
+                None => Ok((false, false)),
+            },
+        )
     }
 
     /// 删除指定 ID 的记录
     pub fn delete_by_id(&self, id: &str) -> Result<bool> {
-        let mut items = self.load_all()?;
-        let original_len = items.len();
-        items.retain(|item| item.id() != id);
-        if items.len() < original_len {
-            self.save_all(&items)?;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        self.transaction(|items| {
+            let original_len = items.len();
+            items.retain(|item| item.id() != id);
+            let changed = items.len() < original_len;
+            Ok((changed, changed))
+        })
     }
 
     /// 条件查询
@@ -131,58 +137,80 @@ impl<T: Serialize + DeserializeOwned + Identifiable> JsonStore<T> {
     where
         F: Fn(&T, &T) -> bool,
     {
-        let mut items = self.load_all()?;
-        let mut index_map: HashMap<String, usize> = items
-            .iter()
-            .enumerate()
-            .map(|(i, item)| (item.id().to_string(), i))
-            .collect();
+        self.transaction(|items| {
+            let mut index_map: HashMap<String, usize> = items
+                .iter()
+                .enumerate()
+                .map(|(i, item)| (item.id().to_string(), i))
+                .collect();
 
-        let mut result = BatchResult::default();
+            let mut result = BatchResult::default();
 
-        for incoming_item in incoming {
-            let id = incoming_item.id().to_string();
-            if let Some(&idx) = index_map.get(&id) {
-                if should_update(&items[idx], &incoming_item) {
-                    items[idx] = incoming_item;
-                    result.updated += 1;
+            for incoming_item in incoming {
+                let id = incoming_item.id().to_string();
+                if let Some(&idx) = index_map.get(&id) {
+                    if should_update(&items[idx], &incoming_item) {
+                        items[idx] = incoming_item;
+                        result.updated += 1;
+                    }
+                } else {
+                    index_map.insert(id, items.len());
+                    items.push(incoming_item);
+                    result.added += 1;
                 }
-            } else {
-                index_map.insert(id, items.len());
-                items.push(incoming_item);
-                result.added += 1;
             }
-        }
 
-        if result.added > 0 || result.updated > 0 {
-            self.save_all(&items)?;
-        }
-        Ok(result)
+            let changed = result.added > 0 || result.updated > 0;
+            Ok((result, changed))
+        })
     }
 
     /// 批量插入不存在的记录（跳过已存在的 ID）
     pub fn batch_insert_new(&self, incoming: Vec<T>) -> Result<usize> {
-        let mut items = self.load_all()?;
-        let existing_ids: std::collections::HashSet<String> =
-            items.iter().map(|item| item.id().to_string()).collect();
+        self.transaction(|items| {
+            let mut existing_ids: std::collections::HashSet<String> =
+                items.iter().map(|item| item.id().to_string()).collect();
 
-        let mut added = 0usize;
-        for item in incoming {
-            if !existing_ids.contains(item.id()) {
-                items.push(item);
-                added += 1;
+            let mut added = 0usize;
+            for item in incoming {
+                if existing_ids.insert(item.id().to_string()) {
+                    items.push(item);
+                    added += 1;
+                }
             }
-        }
 
-        if added > 0 {
-            self.save_all(&items)?;
-        }
-        Ok(added)
+            Ok((added, added > 0))
+        })
     }
 
     /// 批量写入（覆盖）
     pub fn replace_all(&self, items: Vec<T>) -> Result<()> {
-        self.save_all(&items)
+        let _guard = self
+            .mutation_lock
+            .lock()
+            .map_err(|error| anyhow::anyhow!("获取数据写锁失败: {error}"))?;
+        self.save_all_unlocked(&items)
+    }
+
+    /// 在同一个互斥区内完成读取、修改和按需写回。
+    ///
+    /// 闭包返回值中的 `bool` 表示数据是否发生变化；仅在为 `true` 时写入文件。
+    /// 传给闭包的集合已在锁内读取，闭包中不要再次调用本 store 的写方法，
+    /// 否则会尝试重复获取同一把非重入锁。
+    pub fn transaction<R, F>(&self, mutation: F) -> Result<R>
+    where
+        F: FnOnce(&mut Vec<T>) -> Result<(R, bool)>,
+    {
+        let _guard = self
+            .mutation_lock
+            .lock()
+            .map_err(|error| anyhow::anyhow!("获取数据事务锁失败: {error}"))?;
+        let mut items = self.load_all_unlocked()?;
+        let (result, changed) = mutation(&mut items)?;
+        if changed {
+            self.save_all_unlocked(&items)?;
+        }
+        Ok(result)
     }
 
     /// 统计记录数
@@ -195,6 +223,8 @@ impl<T: Serialize + DeserializeOwned + Identifiable> JsonStore<T> {
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
+    use std::sync::{Arc, Barrier};
+    use std::thread;
 
     #[derive(Serialize, Deserialize, Debug, Clone)]
     struct TestItem {
@@ -327,5 +357,73 @@ mod tests {
 
         let items = store.load_all().unwrap();
         assert!(items.is_empty());
+    }
+
+    #[test]
+    fn concurrent_inserts_do_not_lose_updates() {
+        const THREADS: usize = 8;
+        const INSERTS_PER_THREAD: usize = 25;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(setup(tmp.path()));
+        let start = Arc::new(Barrier::new(THREADS));
+        let mut workers = Vec::new();
+
+        for worker_id in 0..THREADS {
+            let store = Arc::clone(&store);
+            let start = Arc::clone(&start);
+            workers.push(thread::spawn(move || {
+                start.wait();
+                for item_id in 0..INSERTS_PER_THREAD {
+                    store
+                        .insert(TestItem {
+                            id: format!("{worker_id}:{item_id}"),
+                            name: format!("worker-{worker_id}"),
+                        })
+                        .unwrap();
+                }
+            }));
+        }
+
+        for worker in workers {
+            worker.join().unwrap();
+        }
+
+        let items = store.load_all().unwrap();
+        assert_eq!(items.len(), THREADS * INSERTS_PER_THREAD);
+        let unique_ids: std::collections::HashSet<_> =
+            items.iter().map(|item| item.id.as_str()).collect();
+        assert_eq!(unique_ids.len(), THREADS * INSERTS_PER_THREAD);
+    }
+
+    #[test]
+    fn concurrent_batch_inserts_do_not_overwrite_each_other() {
+        const THREADS: usize = 4;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(setup(tmp.path()));
+        let start = Arc::new(Barrier::new(THREADS));
+        let workers: Vec<_> = (0..THREADS)
+            .map(|worker_id| {
+                let store = Arc::clone(&store);
+                let start = Arc::clone(&start);
+                thread::spawn(move || {
+                    let batch: Vec<_> = (0..20)
+                        .map(|item_id| TestItem {
+                            id: format!("batch-{worker_id}:{item_id}"),
+                            name: format!("batch-{worker_id}"),
+                        })
+                        .collect();
+                    start.wait();
+                    assert_eq!(store.batch_insert_new(batch).unwrap(), 20);
+                })
+            })
+            .collect();
+
+        for worker in workers {
+            worker.join().unwrap();
+        }
+
+        assert_eq!(store.count().unwrap(), THREADS * 20);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod llm;
 pub mod logger;
 pub mod rpa;
 pub mod storage;
+pub mod task;
 pub mod utils;
 pub mod verify;
 use tauri::Manager;
@@ -47,6 +48,7 @@ pub fn run() {
             command::rpa::run_flow::preflight_job_task,
             command::rpa::run_flow::boss_flow,
             command::rpa::run_flow::rpa_flow,
+            command::rpa::run_flow::start_job_task,
             command::rpa::run_flow::get_job_task_status,
             command::rpa::run_flow::stop_job_task,
             command::rpa::run_flow::read_log_file,

--- a/src-tauri/src/llm/service.rs
+++ b/src-tauri/src/llm/service.rs
@@ -1187,7 +1187,10 @@ mod tests {
 
         // 120 秒已经等满，任何一次重试前都不该再等
         for attempt in 0..5 {
-            assert_eq!(super::retry_plan(&AttemptFailure::Timeout, attempt, &retry), None);
+            assert_eq!(
+                super::retry_plan(&AttemptFailure::Timeout, attempt, &retry),
+                None
+            );
         }
         assert_eq!(
             AttemptFailure::Timeout.into_error(),
@@ -1197,9 +1200,18 @@ mod tests {
 
     #[test]
     fn backoff_doubles_from_the_base_delay() {
-        assert_eq!(super::retry_backoff_delay(500, 0), Duration::from_millis(500));
-        assert_eq!(super::retry_backoff_delay(500, 1), Duration::from_millis(1_000));
-        assert_eq!(super::retry_backoff_delay(500, 2), Duration::from_millis(2_000));
+        assert_eq!(
+            super::retry_backoff_delay(500, 0),
+            Duration::from_millis(500)
+        );
+        assert_eq!(
+            super::retry_backoff_delay(500, 1),
+            Duration::from_millis(1_000)
+        );
+        assert_eq!(
+            super::retry_backoff_delay(500, 2),
+            Duration::from_millis(2_000)
+        );
 
         let retry = retry_config(3, 500);
         let delays: Vec<_> = (0..3)
@@ -1326,7 +1338,9 @@ mod tests {
                     // 密钥缺失同样降级：链存在的意义就是主用服务不可用时兜底
                     0 => Err(AppError::credential("请先配置该大模型服务的 API Key")),
                     // 额度受限也降级
-                    1 => Err(AppError::provider("大模型服务返回 HTTP 429：请求受限或账户额度不足")),
+                    1 => Err(AppError::provider(
+                        "大模型服务返回 HTTP 429：请求受限或账户额度不足",
+                    )),
                     _ => Ok(ok_response("最后一环成功")),
                 }
             }

--- a/src-tauri/src/logger.rs
+++ b/src-tauri/src/logger.rs
@@ -1,7 +1,10 @@
 use std::{
+    cell::RefCell,
     fs::OpenOptions,
     io::Write,
+    marker::PhantomData,
     path::PathBuf,
+    rc::Rc,
     sync::{Mutex, RwLock},
 };
 
@@ -13,8 +16,35 @@ use tauri::Manager;
 use crate::rpa::run_flow::PlatformKind;
 
 static LOG_FILE_PATH: Lazy<RwLock<Option<PathBuf>>> = Lazy::new(|| RwLock::new(None));
-static CURRENT_PLATFORM: Lazy<RwLock<Option<PlatformKind>>> = Lazy::new(|| RwLock::new(None));
 static LOG_IO_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct LogContext {
+    pub task_id: Option<String>,
+    pub platform: Option<PlatformKind>,
+}
+
+thread_local! {
+    /// Logging context belongs to the task's dedicated worker thread. Keeping it
+    /// thread-local prevents concurrent BOSS and Liepin workers from overwriting
+    /// each other's labels.
+    static CURRENT_CONTEXT: RefCell<LogContext> = RefCell::new(LogContext::default());
+}
+
+/// Restores the previous context when a scoped logging operation finishes.
+/// The marker makes the guard non-Send so it cannot be dropped on another thread.
+pub struct LogContextGuard {
+    previous: Option<LogContext>,
+    _thread_bound: PhantomData<Rc<()>>,
+}
+
+impl Drop for LogContextGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.take() {
+            CURRENT_CONTEXT.with(|current| *current.borrow_mut() = previous);
+        }
+    }
+}
 
 pub fn init(app_handle: &tauri::AppHandle) -> Result<()> {
     let data_dir = app_handle
@@ -50,11 +80,28 @@ pub fn clear() -> Result<()> {
 }
 
 pub fn set_platform(platform: Option<PlatformKind>) -> Result<()> {
-    let mut current = CURRENT_PLATFORM
-        .write()
-        .map_err(|e| anyhow!("获取日志平台写锁失败: {}", e))?;
-    *current = platform;
+    CURRENT_CONTEXT.with(|current| current.borrow_mut().platform = platform);
     Ok(())
+}
+
+pub fn set_task_id(task_id: Option<String>) -> Result<()> {
+    CURRENT_CONTEXT.with(|current| current.borrow_mut().task_id = task_id);
+    Ok(())
+}
+
+/// Installs a complete context for the current worker thread and restores the
+/// prior context when the returned guard is dropped.
+pub fn scoped_context(task_id: Option<String>, platform: Option<PlatformKind>) -> LogContextGuard {
+    let context = LogContext { task_id, platform };
+    let previous = CURRENT_CONTEXT.with(|current| current.replace(context));
+    LogContextGuard {
+        previous: Some(previous),
+        _thread_bound: PhantomData,
+    }
+}
+
+pub fn current_context() -> LogContext {
+    CURRENT_CONTEXT.with(|current| current.borrow().clone())
 }
 
 pub fn info(msg: impl ToString) -> Result<()> {
@@ -71,17 +118,21 @@ fn write_log(level: &str, msg: &str) -> Result<()> {
         .map_err(|e| anyhow!("获取日志文件锁失败: {}", e))?;
     let path = path()?;
     let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
-    let platform = CURRENT_PLATFORM
-        .read()
-        .map_err(|e| anyhow!("获取日志平台读锁失败: {}", e))?;
-    let platform_prefix = platform
+    let context = current_context();
+    let task_prefix = context
+        .task_id
         .as_ref()
-        .map(|platform| format!("[{}] ", platform_log_label(*platform)))
+        .map(|task_id| format!("[task={task_id}] "))
+        .unwrap_or_default();
+    let platform_prefix = context
+        .platform
+        .map(|platform| format!("[{}] ", platform_log_label(platform)))
         .unwrap_or_default();
     let line = format!(
-        "[{}] [{}] {}{}\n",
+        "[{}] [{}] {}{}{}\n",
         timestamp,
         level,
+        task_prefix,
         platform_prefix,
         redact(msg)
     );
@@ -139,6 +190,9 @@ pub fn redact(message: &str) -> String {
 mod tests {
     use super::*;
     use crate::rpa::run_flow::PlatformKind;
+    use std::sync::{Arc, Barrier, Mutex as TestMutex};
+
+    static TEST_LOG_LOCK: TestMutex<()> = TestMutex::new(());
 
     fn use_temp_log_file() -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("create temp dir");
@@ -150,6 +204,7 @@ mod tests {
 
     #[test]
     fn prefixes_logs_with_current_platform_and_clears_context() {
+        let _test_guard = TEST_LOG_LOCK.lock().expect("lock logger test");
         let _dir = use_temp_log_file();
 
         info("开始处理岗位").expect("write platform log");
@@ -173,5 +228,76 @@ mod tests {
         assert!(!safe.contains("my resume"));
         assert!(!safe.contains("private prompt"));
         assert!(!safe.contains("standard-secret"));
+    }
+
+    #[test]
+    fn concurrent_thread_contexts_do_not_cross_contaminate_logs() {
+        let _test_guard = TEST_LOG_LOCK.lock().expect("lock logger test");
+        let _dir = use_temp_log_file();
+        set_platform(None).expect("clear test thread platform");
+
+        let start = Arc::new(Barrier::new(2));
+        let boss_start = Arc::clone(&start);
+        let boss = std::thread::spawn(move || {
+            let _context = scoped_context(Some("boss-1".into()), Some(PlatformKind::Boss));
+            boss_start.wait();
+            for index in 0..20 {
+                info(format!("boss-message-{index}")).expect("write boss log");
+                std::thread::yield_now();
+            }
+        });
+
+        let liepin_start = Arc::clone(&start);
+        let liepin = std::thread::spawn(move || {
+            let _context = scoped_context(Some("liepin-2".into()), Some(PlatformKind::Liepin));
+            liepin_start.wait();
+            for index in 0..20 {
+                info(format!("liepin-message-{index}")).expect("write liepin log");
+                std::thread::yield_now();
+            }
+        });
+
+        boss.join().expect("boss worker");
+        liepin.join().expect("liepin worker");
+
+        let content = read_tail_lines(100).expect("read concurrent log");
+        for line in content.lines() {
+            if line.contains("boss-message-") {
+                assert!(line.contains("[task=boss-1] [BOSS]"), "{line}");
+                assert!(!line.contains("猎聘"), "{line}");
+            }
+            if line.contains("liepin-message-") {
+                assert!(line.contains("[task=liepin-2] [猎聘]"), "{line}");
+                assert!(!line.contains("BOSS"), "{line}");
+            }
+        }
+    }
+
+    #[test]
+    fn scoped_context_restores_previous_thread_context() {
+        let _test_guard = TEST_LOG_LOCK.lock().expect("lock logger test");
+        set_platform(Some(PlatformKind::Boss)).expect("set outer platform");
+        set_task_id(Some("outer".into())).expect("set outer task");
+
+        {
+            let _context = scoped_context(Some("inner".into()), Some(PlatformKind::Liepin));
+            assert_eq!(
+                current_context(),
+                LogContext {
+                    task_id: Some("inner".into()),
+                    platform: Some(PlatformKind::Liepin),
+                }
+            );
+        }
+
+        assert_eq!(
+            current_context(),
+            LogContext {
+                task_id: Some("outer".into()),
+                platform: Some(PlatformKind::Boss),
+            }
+        );
+        set_task_id(None).expect("clear outer task");
+        set_platform(None).expect("clear outer platform");
     }
 }

--- a/src-tauri/src/resource/app_config.yaml
+++ b/src-tauri/src/resource/app_config.yaml
@@ -1,7 +1,8 @@
-schema_version: 2
+schema_version: 3
 onboarding_completed: false
 llm_config: null
-job_filter_config:
+default_job_profile_id: default
+job_filter_config: &default_job_filter
   query: 大模型应用
   city: 101020100
   job_type: 1901
@@ -24,7 +25,7 @@ job_filter_config:
   enable_semantic_filter: false
   semantic_filter_intent: null
   regex_rules: []
-greet_config:
+greet_config: &default_greet
   enable_llm: true
   reply_prompt: |-
     你是一个求职者，正在BOSS直聘上与招聘方沟通。请根据以下内容生成一段开场的打招呼用语。
@@ -52,7 +53,7 @@ greet_config:
   default_template:
     - resource_type: LLM
       content: ""
-replay_config:
+replay_config: &default_replay
   enable_auto_replay: true
   templates:
     - regex_rule:
@@ -106,7 +107,23 @@ browser_config:
   user_data_dir: ""
   chrome_exe_path: ""
   max_parallel_tasks: 2
-resume_config:
+resume_config: &default_resume
   inject_llm_context: true
   resume_path: ""
   resume_content: ""
+job_profiles:
+  - id: default
+    name: 默认求职方案
+    description: null
+    archived: false
+    job_filter_config: *default_job_filter
+    platform_filter_config:
+      liepin:
+        dq: null
+        salary_code: null
+        pub_time: null
+        work_year_code: null
+        comp_tag: []
+    resume_config: *default_resume
+    greet_config: *default_greet
+    replay_config: *default_replay

--- a/src-tauri/src/resource/app_config.yaml
+++ b/src-tauri/src/resource/app_config.yaml
@@ -105,6 +105,7 @@ replay_config:
 browser_config:
   user_data_dir: ""
   chrome_exe_path: ""
+  max_parallel_tasks: 2
 resume_config:
   inject_llm_context: true
   resume_path: ""

--- a/src-tauri/src/rpa/boss/handler/mod.rs
+++ b/src-tauri/src/rpa/boss/handler/mod.rs
@@ -8,9 +8,9 @@ mod sync_chat_history;
 
 pub use login::login;
 pub use login_check::login_check;
-pub use position_say_hello::position_say_hello;
-pub use reply_unread::reply_unread;
+pub use position_say_hello::{position_say_hello, position_say_hello_on_page};
 pub(crate) use reply_unread::{parse_chat_messages, parse_encrypt_job_id};
+pub use reply_unread::{reply_unread, reply_unread_on_page};
 pub use send_message::send_messages;
 pub use send_resume::send_resume;
-pub use sync_chat_history::sync_chat_history;
+pub use sync_chat_history::{sync_chat_history, sync_chat_history_on_page};

--- a/src-tauri/src/rpa/boss/handler/position_say_hello.rs
+++ b/src-tauri/src/rpa/boss/handler/position_say_hello.rs
@@ -633,11 +633,16 @@ fn extract_job_id(url: &str) -> Option<&str> {
     Some(&url[start..end])
 }
 
-fn save_job_detail(job_id: &str, greet_job: &GreetJob) {
+fn save_job_detail(job_id: &str, greet_job: &GreetJob, config: &AppRuntimeConfig) {
     let now = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let active = config.active_job_profile.as_ref();
     let job_detail = JobDetail {
         id: job_id.to_string(),
         platform: "boss".to_string(),
+        source_task_id: crate::rpa::run_flow::current_job_task_id(),
+        profile_id: active.map(|profile| profile.id.clone()),
+        profile_name: active.map(|profile| profile.name.clone()),
+        profile_snapshot_id: active.map(|profile| profile.snapshot_id.clone()),
         title: greet_job.title.clone(),
         company_name: greet_job.company_name.clone(),
         detail: greet_job.detail.clone(),
@@ -932,7 +937,7 @@ async fn handle_greet_on_work_tab(
     // 已显示成功提示但站点没有跳转聊天页时，默认招呼已经真实发出；不能误判为失败。
     if greet_success_seen {
         logger::info("站点已确认向 BOSS 发送消息，未跳转聊天页，当前岗位视为建联成功")?;
-        save_job_detail(&greet_job.platform_job_id, &greet_job);
+        save_job_detail(&greet_job.platform_job_id, &greet_job, &config);
         return Ok(());
     }
 
@@ -986,7 +991,7 @@ async fn handle_send_message_on_chat_page(
     send_if_any(resources, |resources| send_messages(page, resources))?;
 
     // 保存该岗位至本地数据库
-    save_job_detail(&greet_job.platform_job_id, &greet_job);
+    save_job_detail(&greet_job.platform_job_id, &greet_job, &config);
 
     sleep_random_ms(1200, 2000);
 

--- a/src-tauri/src/rpa/boss/handler/position_say_hello.rs
+++ b/src-tauri/src/rpa/boss/handler/position_say_hello.rs
@@ -25,221 +25,221 @@ pub async fn position_say_hello(
     app_runtime_config: &AppRuntimeConfig,
 ) -> Result<(), anyhow::Error> {
     let app_runtime_config = app_runtime_config.clone();
-    let search_url = build_job_search_url(&app_runtime_config.job_filter_config);
-    browser::with_browser(|page| {
+    browser::with_browser(|connection| {
         Box::pin(async move {
-            // 加载本地已处理的岗位ID，用于去重
-            let mut processed_job_ids: HashSet<String> = job_detail_dao::list()
-                .unwrap_or_default()
-                .into_iter()
-                .map(|j| j.id)
-                .collect();
-            logger::info(format!("本地已存储 {} 条岗位记录", processed_job_ids.len()))?;
+            position_say_hello_on_page(connection, connection.tab(), &app_runtime_config).await
+        })
+    })
+    .await
+}
 
-            // 在 page.get 之前开始监听，捕获首次加载触发的 joblist 请求
-            let joblist_listener = page.listen_url("wapi/zpgeek/search/joblist.json")?;
+/// Run the BOSS job-hunting flow on the task-owned main tab.
+pub async fn position_say_hello_on_page(
+    connection: &ChromiumPage,
+    page: &Page,
+    app_runtime_config: &AppRuntimeConfig,
+) -> Result<(), anyhow::Error> {
+    let app_runtime_config = app_runtime_config.clone();
+    let search_url = build_job_search_url(&app_runtime_config.job_filter_config);
+    // 加载本地已处理的岗位ID，用于去重
+    let mut processed_job_ids: HashSet<String> = job_detail_dao::list()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|j| j.id)
+        .collect();
+    logger::info(format!("本地已存储 {} 条岗位记录", processed_job_ids.len()))?;
 
-            page.get(&search_url)?;
-            if let Err(error) = page.wait(".rec-job-list", JOB_LIST_WAIT_TIMEOUT) {
-                // 直接把 CDP 超时抛给用户没有任何可操作性，这里补齐当前页面上下文再给中文提示
-                let current_url = page.url().unwrap_or_else(|_| "未知 URL".to_string());
-                let page_text = page_text_snippet(page);
-                return Err(anyhow::anyhow!(job_list_wait_error(
-                    &current_url,
-                    &page_text,
-                    &error.to_string(),
-                )));
+    // 在 page.get 之前开始监听，捕获首次加载触发的 joblist 请求
+    let joblist_listener = page.listen_url("wapi/zpgeek/search/joblist.json")?;
+
+    page.get(&search_url)?;
+    if let Err(error) = page.wait(".rec-job-list", JOB_LIST_WAIT_TIMEOUT) {
+        // 直接把 CDP 超时抛给用户没有任何可操作性，这里补齐当前页面上下文再给中文提示
+        let current_url = page.url().unwrap_or_else(|_| "未知 URL".to_string());
+        let page_text = page_text_snippet(page);
+        return Err(anyhow::anyhow!(job_list_wait_error(
+            &current_url,
+            &page_text,
+            &error.to_string(),
+        )));
+    }
+
+    // 消费首次 page.get 触发的 joblist 响应，初始化 seen_job_ids
+    let mut seen_job_ids: HashSet<String> = HashSet::new();
+    if let Ok(Some(packet)) = joblist_listener.wait(Duration::from_secs(10)) {
+        let (first_ids, _) = parse_joblist_response(&packet);
+        seen_job_ids.extend(first_ids);
+    }
+    let mut no_new_count = 0u32;
+    let mut stats = RoundStats::default();
+
+    let stop_reason = 'outer: loop {
+        if is_job_task_stop_requested() {
+            break 'outer StopReason::UserStopped;
+        }
+
+        let jeb_card_area_eles = page.eles(".card-area")?;
+        logger::info(format!("页面加载到{}条岗位卡片", jeb_card_area_eles.len()))?;
+        if jeb_card_area_eles.is_empty() {
+            break 'outer StopReason::EmptyList;
+        }
+
+        // 记录进入本页时的累计值，页末据此算出“本页”增量
+        let round_base = stats.clone();
+
+        for job_card_area_ele in jeb_card_area_eles {
+            if is_job_task_stop_requested() {
+                break 'outer StopReason::UserStopped;
             }
-
-            // 消费首次 page.get 触发的 joblist 响应，初始化 seen_job_ids
-            let mut seen_job_ids: HashSet<String> = HashSet::new();
-            if let Ok(Some(packet)) = joblist_listener.wait(Duration::from_secs(10)) {
-                let (first_ids, _) = parse_joblist_response(&packet);
-                seen_job_ids.extend(first_ids);
-            }
-            let mut no_new_count = 0u32;
-            let mut stats = RoundStats::default();
-
-            let stop_reason = 'outer: loop {
-                if is_job_task_stop_requested() {
-                    break 'outer StopReason::UserStopped;
+            stats.scanned += 1;
+            let greet_job = match read_job_card(page, &job_card_area_ele, &processed_job_ids) {
+                Ok(CardOutcome::Ready(greet_job)) => *greet_job,
+                Ok(CardOutcome::Skipped(reason)) => {
+                    stats.record_skip(reason);
+                    // 全静默会让用户以为程序卡死，这里按批次给出进度提示
+                    let skipped = stats.skipped_known() - round_base.skipped_known();
+                    if should_log_skip_progress(skipped) {
+                        logger::info(format!("已跳过 {} 条已浏览/已投递岗位，继续扫描", skipped))?;
+                    }
+                    continue;
                 }
-
-                let jeb_card_area_eles = page.eles(".card-area")?;
-                logger::info(format!("页面加载到{}条岗位卡片", jeb_card_area_eles.len()))?;
-                if jeb_card_area_eles.is_empty() {
-                    break 'outer StopReason::EmptyList;
-                }
-
-                // 记录进入本页时的累计值，页末据此算出“本页”增量
-                let round_base = stats.clone();
-
-                for job_card_area_ele in jeb_card_area_eles {
-                    if is_job_task_stop_requested() {
-                        break 'outer StopReason::UserStopped;
-                    }
-                    stats.scanned += 1;
-                    let greet_job =
-                        match read_job_card(page, &job_card_area_ele, &processed_job_ids) {
-                            Ok(CardOutcome::Ready(greet_job)) => *greet_job,
-                            Ok(CardOutcome::Skipped(reason)) => {
-                                stats.record_skip(reason);
-                                // 全静默会让用户以为程序卡死，这里按批次给出进度提示
-                                let skipped = stats.skipped_known() - round_base.skipped_known();
-                                if should_log_skip_progress(skipped) {
-                                    logger::info(format!(
-                                        "已跳过 {} 条已浏览/已投递岗位，继续扫描",
-                                        skipped
-                                    ))?;
-                                }
-                                continue;
-                            }
-                            Err(error) => {
-                                stats.read_failed += 1;
-                                logger::warning(card_failure_message(&error))?;
-                                continue;
-                            }
-                        };
-
-                    logger::info(format!(
-                        "当前处理岗位:{} 公司:{}",
-                        greet_job.title, greet_job.company_name
-                    ))?;
-
-                    let filter_decision = verify::filter_decision(&greet_job, &app_runtime_config);
-                    if !filter_decision.matched {
-                        stats.skipped_rule += 1;
-                        logger::info(format!("岗位不匹配，跳过：{}", filter_decision.reason))?;
-                        continue;
-                    }
-                    if app_runtime_config.job_filter_config.enable_semantic_filter {
-                        match crate::llm::evaluate_job_match(&app_runtime_config, &greet_job).await
-                        {
-                            Ok(decision) if decision.matched => logger::info(format!(
-                                "AI 岗位复核通过（{}分）：{}",
-                                decision.score, decision.reason
-                            ))?,
-                            Ok(decision) => {
-                                stats.skipped_ai += 1;
-                                logger::info(format!(
-                                    "AI 岗位复核未通过，跳过（{}分）：{}",
-                                    decision.score, decision.reason
-                                ))?;
-                                continue;
-                            }
-                            Err(error) => {
-                                stats.skipped_ai += 1;
-                                logger::warning(format!(
-                                    "AI 岗位复核失败，为避免误投已跳过：{}",
-                                    error
-                                ))?;
-                                continue;
-                            }
-                        }
-                    }
-                    match handle_greet(page, greet_job.clone(), app_runtime_config.clone()).await {
-                        Ok(()) => {}
-                        Err(error) => {
-                            stats.greet_failed += 1;
-                            logger::warning(greet_failure_message(
-                                &greet_job.title,
-                                &greet_job.company_name,
-                                &error,
-                            ))?;
-                            if should_continue_after_greet_failure() {
-                                continue;
-                            }
-                            // 目前 should_continue_after_greet_failure 恒为 true，
-                            // 这里仅作为“单次失败即终止”策略的兜底出口
-                            break 'outer StopReason::GreetFailureAborted;
-                        }
-                    }
-                    if is_job_task_stop_requested() {
-                        break 'outer StopReason::UserStopped;
-                    }
-
-                    stats.greet_success += 1;
-                    logger::info(format!("{} 初次沟通成功", greet_job.title))?;
-                    processed_job_ids.insert(greet_job.platform_job_id.clone());
-                    sleep_random_ms(3000, 5000);
-                }
-
-                // 本页处理结果汇总：一条都没进入打招呼流程时给出聚合提示，避免界面长时间无输出
-                let round = stats.since(&round_base);
-                if round.scanned > 0 {
-                    if round.engaged() == 0 {
-                        logger::info(format!(
-                            "本页 {} 条岗位均已处理过或不匹配，继续向下加载",
-                            round.scanned
-                        ))?;
-                    } else {
-                        logger::info(format!("本页处理完成：{}", round.summary()))?;
-                    }
-                }
-
-                // 检查是否已触底
-                if page.ele(".loading-wait")?.is_none() {
-                    break 'outer StopReason::ReachedBottom;
-                }
-
-                // 设置监听 → 滚动 → 等待 joblist API 响应，检测是否有新岗位
-                let joblist_listener = page.listen_url("wapi/zpgeek/search/joblist.json")?;
-                let scroll_probe = scroll_bottom_probe(page)?;
-
-                match joblist_listener.wait(Duration::from_secs(10)) {
-                    Ok(Some(packet)) => {
-                        let (api_ids, has_more) = parse_joblist_response(&packet);
-
-                        if !has_more {
-                            break 'outer StopReason::NoMoreFromApi;
-                        }
-
-                        let new_ids: HashSet<String> = api_ids
-                            .into_iter()
-                            .filter(|id| !seen_job_ids.contains(id))
-                            .collect();
-
-                        if new_ids.is_empty() {
-                            no_new_count += 1;
-                            if no_new_count >= MAX_NO_NEW_RETRY {
-                                break 'outer StopReason::NoNewJobs;
-                            }
-                            logger::info(format!(
-                                "第 {}/{} 次滚动未加载到新岗位，重试中",
-                                no_new_count, MAX_NO_NEW_RETRY
-                            ))?;
-                            continue;
-                        }
-
-                        no_new_count = 0;
-                        seen_job_ids.extend(new_ids);
-                    }
-                    _ => {
-                        no_new_count += 1;
-                        if no_new_count >= MAX_NO_NEW_RETRY {
-                            break 'outer StopReason::ApiTimeout;
-                        }
-                        logger::info(format!(
-                            "第 {}/{} 次等待岗位接口响应超时，重试中（{}）",
-                            no_new_count,
-                            MAX_NO_NEW_RETRY,
-                            scroll_probe.describe()
-                        ))?;
-                        continue;
-                    }
+                Err(error) => {
+                    stats.read_failed += 1;
+                    logger::warning(card_failure_message(&error))?;
+                    continue;
                 }
             };
 
             logger::info(format!(
-                "本轮求职任务结束：{}。{}",
-                stop_reason.describe(),
-                stats.total_summary()
+                "当前处理岗位:{} 公司:{}",
+                greet_job.title, greet_job.company_name
             ))?;
 
-            Ok(())
-        })
-    })
-    .await?;
+            let filter_decision = verify::filter_decision(&greet_job, &app_runtime_config);
+            if !filter_decision.matched {
+                stats.skipped_rule += 1;
+                logger::info(format!("岗位不匹配，跳过：{}", filter_decision.reason))?;
+                continue;
+            }
+            if app_runtime_config.job_filter_config.enable_semantic_filter {
+                match crate::llm::evaluate_job_match(&app_runtime_config, &greet_job).await {
+                    Ok(decision) if decision.matched => logger::info(format!(
+                        "AI 岗位复核通过（{}分）：{}",
+                        decision.score, decision.reason
+                    ))?,
+                    Ok(decision) => {
+                        stats.skipped_ai += 1;
+                        logger::info(format!(
+                            "AI 岗位复核未通过，跳过（{}分）：{}",
+                            decision.score, decision.reason
+                        ))?;
+                        continue;
+                    }
+                    Err(error) => {
+                        stats.skipped_ai += 1;
+                        logger::warning(format!("AI 岗位复核失败，为避免误投已跳过：{}", error))?;
+                        continue;
+                    }
+                }
+            }
+            match handle_greet(connection, greet_job.clone(), app_runtime_config.clone()).await {
+                Ok(()) => {}
+                Err(error) => {
+                    stats.greet_failed += 1;
+                    logger::warning(greet_failure_message(
+                        &greet_job.title,
+                        &greet_job.company_name,
+                        &error,
+                    ))?;
+                    if should_continue_after_greet_failure() {
+                        continue;
+                    }
+                    // 目前 should_continue_after_greet_failure 恒为 true，
+                    // 这里仅作为“单次失败即终止”策略的兜底出口
+                    break 'outer StopReason::GreetFailureAborted;
+                }
+            }
+            if is_job_task_stop_requested() {
+                break 'outer StopReason::UserStopped;
+            }
+
+            stats.greet_success += 1;
+            logger::info(format!("{} 初次沟通成功", greet_job.title))?;
+            processed_job_ids.insert(greet_job.platform_job_id.clone());
+            sleep_random_ms(3000, 5000);
+        }
+
+        // 本页处理结果汇总：一条都没进入打招呼流程时给出聚合提示，避免界面长时间无输出
+        let round = stats.since(&round_base);
+        if round.scanned > 0 {
+            if round.engaged() == 0 {
+                logger::info(format!(
+                    "本页 {} 条岗位均已处理过或不匹配，继续向下加载",
+                    round.scanned
+                ))?;
+            } else {
+                logger::info(format!("本页处理完成：{}", round.summary()))?;
+            }
+        }
+
+        // 检查是否已触底
+        if page.ele(".loading-wait")?.is_none() {
+            break 'outer StopReason::ReachedBottom;
+        }
+
+        // 设置监听 → 滚动 → 等待 joblist API 响应，检测是否有新岗位
+        let joblist_listener = page.listen_url("wapi/zpgeek/search/joblist.json")?;
+        let scroll_probe = scroll_bottom_probe(page)?;
+
+        match joblist_listener.wait(Duration::from_secs(10)) {
+            Ok(Some(packet)) => {
+                let (api_ids, has_more) = parse_joblist_response(&packet);
+
+                if !has_more {
+                    break 'outer StopReason::NoMoreFromApi;
+                }
+
+                let new_ids: HashSet<String> = api_ids
+                    .into_iter()
+                    .filter(|id| !seen_job_ids.contains(id))
+                    .collect();
+
+                if new_ids.is_empty() {
+                    no_new_count += 1;
+                    if no_new_count >= MAX_NO_NEW_RETRY {
+                        break 'outer StopReason::NoNewJobs;
+                    }
+                    logger::info(format!(
+                        "第 {}/{} 次滚动未加载到新岗位，重试中",
+                        no_new_count, MAX_NO_NEW_RETRY
+                    ))?;
+                    continue;
+                }
+
+                no_new_count = 0;
+                seen_job_ids.extend(new_ids);
+            }
+            _ => {
+                no_new_count += 1;
+                if no_new_count >= MAX_NO_NEW_RETRY {
+                    break 'outer StopReason::ApiTimeout;
+                }
+                logger::info(format!(
+                    "第 {}/{} 次等待岗位接口响应超时，重试中（{}）",
+                    no_new_count,
+                    MAX_NO_NEW_RETRY,
+                    scroll_probe.describe()
+                ))?;
+                continue;
+            }
+        }
+    };
+
+    logger::info(format!(
+        "本轮求职任务结束：{}。{}",
+        stop_reason.describe(),
+        stats.total_summary()
+    ))?;
 
     Ok(())
 }
@@ -428,7 +428,7 @@ fn job_list_wait_error(url: &str, page_text: &str, source: &str) -> String {
 }
 
 /// 抓取页面可见文本片段，仅用于超时诊断，失败时返回空串
-fn page_text_snippet(page: &ChromiumPage) -> String {
+fn page_text_snippet(page: &Page) -> String {
     page.ele("body")
         .ok()
         .flatten()
@@ -445,7 +445,7 @@ fn card_failure_message(error: &anyhow::Error) -> String {
 }
 
 fn read_job_card(
-    page: &ChromiumPage,
+    page: &Page,
     job_card_area_ele: &Element,
     processed_job_ids: &HashSet<String>,
 ) -> Result<CardOutcome, anyhow::Error> {
@@ -1038,14 +1038,14 @@ fn scroll_height_from_value(value: &Value) -> Option<f64> {
 
 // 滚动到底部（兼容旧签名的包装，忽略高度探测结果）
 #[allow(dead_code)]
-pub fn scroll_bottom(page: &ChromiumPage) -> Result<(), anyhow::Error> {
+pub fn scroll_bottom(page: &Page) -> Result<(), anyhow::Error> {
     scroll_bottom_probe(page).map(|_| ())
 }
 
 /// 滚动到底部并返回滚动前后的页面高度。
 /// 分两步执行 JS（先上滚、再下滚），中间用 `sleep_random_ms` 留出真实间隔，
 /// 比在 JS 里写 setTimeout 更可控，也更贴近真人操作。
-fn scroll_bottom_probe(page: &ChromiumPage) -> Result<ScrollProbe, anyhow::Error> {
+fn scroll_bottom_probe(page: &Page) -> Result<ScrollProbe, anyhow::Error> {
     let nudged = page.run_js_await(SCROLL_NUDGE_UP_SCRIPT)?;
     let height_before = scroll_height_from_value(&nudged).unwrap_or_default();
 
@@ -1072,7 +1072,7 @@ fn _is_bottom_value(value: &Value) -> Result<bool, anyhow::Error> {
 }
 
 // 判断是否到底部
-pub fn _is_bottom(page: &ChromiumPage) -> Result<bool, anyhow::Error> {
+pub fn _is_bottom(page: &Page) -> Result<bool, anyhow::Error> {
     let script: &str = r#"
 (()=>{
 const html = document.documentElement;

--- a/src-tauri/src/rpa/boss/handler/reply_unread.rs
+++ b/src-tauri/src/rpa/boss/handler/reply_unread.rs
@@ -38,144 +38,144 @@ pub async fn reply_unread(
 ) -> Result<Vec<UnreadChat>, anyhow::Error> {
     let app_runtime_config = app_runtime_config.clone();
     browser::with_new_tab(|page| {
-        Box::pin(async move {
-            logger::info("正在打开沟通页面")?;
-            page.get(BOSS_CHAT_URL)?;
-            page.wait(".label-list .label-name", Duration::from_secs(10))?;
+        Box::pin(async move { reply_unread_on_page(page, &app_runtime_config).await })
+    })
+    .await
+}
 
-            let replay_config = app_runtime_config.replay_config.clone();
-            loop {
-                if is_job_task_stop_requested() {
-                    logger::info("沟通任务已结束")?;
-                    return Ok(());
-                }
-                click_label(page, "未读")?;
-                page.wait(".user-list-content", Duration::from_secs(10))?;
-                sleep_random_ms(800, 1000);
-                let user_card_eles = page.elements(".user-list-content .friend-content")?;
-                if user_card_eles.is_empty() {
-                    logger::info("没有未读消息")?;
-                    break;
-                }
-                logger::info(format!("当前未读会话数: {}", user_card_eles.len()))?;
-                for user_card_ele in user_card_eles {
-                    if is_job_task_stop_requested() {
-                        logger::info("沟通任务已结束")?;
-                        return Ok(());
-                    }
+/// Process BOSS unread conversations on a caller-owned task tab.
+pub async fn reply_unread_on_page(
+    page: &rust_drission::Page,
+    app_runtime_config: &AppRuntimeConfig,
+) -> Result<Vec<UnreadChat>, anyhow::Error> {
+    let app_runtime_config = app_runtime_config.clone();
+    logger::info("正在打开沟通页面")?;
+    page.get(BOSS_CHAT_URL)?;
+    page.wait(".label-list .label-name", Duration::from_secs(10))?;
 
-                    let history_listener = page.listen_url("zpchat/geek/historyMsg")?;
-                    let boss_data_listener = page.listen_url("zpchat/geek/getBossData")?;
-                    user_card_ele.click()?;
+    let replay_config = app_runtime_config.replay_config.clone();
+    loop {
+        if is_job_task_stop_requested() {
+            logger::info("沟通任务已结束")?;
+            return Ok(Vec::new());
+        }
+        click_label(page, "未读")?;
+        page.wait(".user-list-content", Duration::from_secs(10))?;
+        sleep_random_ms(800, 1000);
+        let user_card_eles = page.elements(".user-list-content .friend-content")?;
+        if user_card_eles.is_empty() {
+            logger::info("没有未读消息")?;
+            break;
+        }
+        logger::info(format!("当前未读会话数: {}", user_card_eles.len()))?;
+        for user_card_ele in user_card_eles {
+            if is_job_task_stop_requested() {
+                logger::info("沟通任务已结束")?;
+                return Ok(Vec::new());
+            }
 
-                    // 检查发送简历 是否被禁用 回复阶段 若对方没有回复 则无法发送简历
-                    let btn = page.element(".toolbar-btn.unable")?;
-                    if let Some(btn) = btn {
-                        let aria_label = btn.attr("aria-label")?;
-                        if aria_label.contains("等待对方回复") {
-                            logger::info("简历已投递，跳过后续处理")?;
-                            continue;
-                        }
-                    }
+            let history_listener = page.listen_url("zpchat/geek/historyMsg")?;
+            let boss_data_listener = page.listen_url("zpchat/geek/getBossData")?;
+            user_card_ele.click()?;
 
-                    sleep_random_ms(500, 800);
-
-                    let job_id = match boss_data_listener.wait(Duration::from_secs(10)) {
-                        Ok(Some(packet)) => match packet.body {
-                            Some(b) => {
-                                let body_str = String::from_utf8(b).unwrap_or_default();
-                                parse_encrypt_job_id(&body_str)
-                            }
-                            None => None,
-                        },
-                        _ => None,
-                    };
-                    // 别人请求给我们 我们确认并发送简历
-                    if page.ele(".toolbar-btn")?.is_some() {
-                        // 点击确认
-                        page.click(".toolbar-btn")?;
-                        // 同意
-                        sleep_random_ms(500, 800);
-                        if page.ele(".panel-resume")?.is_some() {
-                            page.click(".panel-resume .btns .btn-sure-v2")?;
-                            continue;
-                        }
-                    } else {
-                        // 主动发送简历投递请求
-                        send_resume(page)?;
-                        logger::info("主动发起简历投递请求成功")?;
-                        continue;
-                    }
-
-                    if let Some(ref jid) = job_id {
-                        logger::info(format!("获取到 jobId: {}", jid))?;
-                        mark_resume_sent(jid);
-                    }
-
-                    let packet = match history_listener.wait(Duration::from_secs(10)) {
-                        Ok(Some(p)) => p,
-                        Ok(None) => {
-                            logger::warning("等待 historyMsg 响应超时，跳过")?;
-                            continue;
-                        }
-                        Err(e) => {
-                            logger::warning(format!("监听 historyMsg 失败: {e}，跳过"))?;
-                            continue;
-                        }
-                    };
-
-                    let body_bytes = match packet.body {
-                        Some(b) => b,
-                        None => {
-                            logger::warning("historyMsg 响应 body 为空，跳过")?;
-                            continue;
-                        }
-                    };
-                    let body_str =
-                        String::from_utf8(body_bytes).context("historyMsg 响应非 UTF-8 编码")?;
-
-                    let chat_messages = parse_chat_messages(&body_str)?;
-                    let last_msg = chat_messages
-                        .last()
-                        .map(|m| m.text.as_str())
-                        .unwrap_or("(空)");
-                    logger::info(format!(
-                        "处理第会话，最近消息: {}",
-                        truncate_str(last_msg, 30)
-                    ))?;
-
-                    // 增量保存聊天记录
-                    if let Some(ref jid) = job_id {
-                        if let Err(e) = chat_message_dao::save_incremental(jid, &chat_messages) {
-                            let _ = logger::warning(format!("保存聊天记录失败: {}", e));
-                        }
-                    }
-
-                    if let Some(resources) = resolve_reply_resources(
-                        &app_runtime_config,
-                        &replay_config,
-                        &chat_messages,
-                        job_id,
-                    )
-                    .await?
-                    {
-                        send_messages(page, resources)?;
-                        logger::info("回复消息已发送")?;
-                    } else {
-                        logger::info("未匹配到回复模板，跳过")?;
-                    }
-
-                    sleep_random_ms(3000, 5000);
-                }
-                if is_job_task_stop_requested() {
-                    break;
+            // 检查发送简历 是否被禁用 回复阶段 若对方没有回复 则无法发送简历
+            let btn = page.element(".toolbar-btn.unable")?;
+            if let Some(btn) = btn {
+                let aria_label = btn.attr("aria-label")?;
+                if aria_label.contains("等待对方回复") {
+                    logger::info("简历已投递，跳过后续处理")?;
+                    continue;
                 }
             }
-            Ok(())
-        })
-    })
-    .await?;
 
+            sleep_random_ms(500, 800);
+
+            let job_id = match boss_data_listener.wait(Duration::from_secs(10)) {
+                Ok(Some(packet)) => match packet.body {
+                    Some(b) => {
+                        let body_str = String::from_utf8(b).unwrap_or_default();
+                        parse_encrypt_job_id(&body_str)
+                    }
+                    None => None,
+                },
+                _ => None,
+            };
+            // 别人请求给我们 我们确认并发送简历
+            if page.ele(".toolbar-btn")?.is_some() {
+                // 点击确认
+                page.click(".toolbar-btn")?;
+                // 同意
+                sleep_random_ms(500, 800);
+                if page.ele(".panel-resume")?.is_some() {
+                    page.click(".panel-resume .btns .btn-sure-v2")?;
+                    continue;
+                }
+            } else {
+                // 主动发送简历投递请求
+                send_resume(page)?;
+                logger::info("主动发起简历投递请求成功")?;
+                continue;
+            }
+
+            if let Some(ref jid) = job_id {
+                logger::info(format!("获取到 jobId: {}", jid))?;
+                mark_resume_sent(jid);
+            }
+
+            let packet = match history_listener.wait(Duration::from_secs(10)) {
+                Ok(Some(p)) => p,
+                Ok(None) => {
+                    logger::warning("等待 historyMsg 响应超时，跳过")?;
+                    continue;
+                }
+                Err(e) => {
+                    logger::warning(format!("监听 historyMsg 失败: {e}，跳过"))?;
+                    continue;
+                }
+            };
+
+            let body_bytes = match packet.body {
+                Some(b) => b,
+                None => {
+                    logger::warning("historyMsg 响应 body 为空，跳过")?;
+                    continue;
+                }
+            };
+            let body_str = String::from_utf8(body_bytes).context("historyMsg 响应非 UTF-8 编码")?;
+
+            let chat_messages = parse_chat_messages(&body_str)?;
+            let last_msg = chat_messages
+                .last()
+                .map(|m| m.text.as_str())
+                .unwrap_or("(空)");
+            logger::info(format!(
+                "处理第会话，最近消息: {}",
+                truncate_str(last_msg, 30)
+            ))?;
+
+            // 增量保存聊天记录
+            if let Some(ref jid) = job_id {
+                if let Err(e) = chat_message_dao::save_incremental(jid, &chat_messages) {
+                    let _ = logger::warning(format!("保存聊天记录失败: {}", e));
+                }
+            }
+
+            if let Some(resources) =
+                resolve_reply_resources(&app_runtime_config, &replay_config, &chat_messages, job_id)
+                    .await?
+            {
+                send_messages(page, resources)?;
+                logger::info("回复消息已发送")?;
+            } else {
+                logger::info("未匹配到回复模板，跳过")?;
+            }
+
+            sleep_random_ms(3000, 5000);
+        }
+        if is_job_task_stop_requested() {
+            break;
+        }
+    }
     Ok(Vec::new())
 }
 

--- a/src-tauri/src/rpa/boss/handler/reply_unread.rs
+++ b/src-tauri/src/rpa/boss/handler/reply_unread.rs
@@ -7,7 +7,7 @@ use rust_drission::utils::sleep_random_ms;
 use crate::{
     browser,
     config::{AppRuntimeConfig, ReplayResourceType, ReplyResource, ReplyTemplate},
-    dao::{chat_message_dao, job_detail_dao},
+    dao::{chat_message_dao, job_detail_dao, profile_snapshot_dao},
     llm, logger,
     rpa::{
         boss::{
@@ -53,7 +53,6 @@ pub async fn reply_unread_on_page(
     page.get(BOSS_CHAT_URL)?;
     page.wait(".label-list .label-name", Duration::from_secs(10))?;
 
-    let replay_config = app_runtime_config.replay_config.clone();
     loop {
         if is_job_task_stop_requested() {
             logger::info("沟通任务已结束")?;
@@ -160,9 +159,36 @@ pub async fn reply_unread_on_page(
                 }
             }
 
-            if let Some(resources) =
-                resolve_reply_resources(&app_runtime_config, &replay_config, &chat_messages, job_id)
-                    .await?
+            let job = job_id.as_deref().and_then(|id| {
+                job_detail_dao::find_by_platform_job_id("boss", id)
+                    .ok()
+                    .flatten()
+            });
+            let (conversation_config, source) =
+                profile_snapshot_dao::resolve_for_job(&app_runtime_config, job.as_ref())
+                    .map_err(anyhow::Error::msg)?;
+            match source {
+                profile_snapshot_dao::ResolutionSource::Snapshot => {}
+                profile_snapshot_dao::ResolutionSource::CurrentProfile => {
+                    logger::warning("岗位方案快照缺失，按当前同名方案回复")?;
+                }
+                profile_snapshot_dao::ResolutionSource::DefaultProfile => {
+                    logger::warning("会话没有可恢复的求职方案归属，按默认方案回复")?;
+                }
+            }
+
+            if !conversation_config.replay_config.enable_auto_replay {
+                logger::info("该会话所属求职方案未启用自动回复，跳过")?;
+                continue;
+            }
+
+            if let Some(resources) = resolve_reply_resources(
+                &conversation_config,
+                &conversation_config.replay_config,
+                &chat_messages,
+                job_id,
+            )
+            .await?
             {
                 send_messages(page, resources)?;
                 logger::info("回复消息已发送")?;

--- a/src-tauri/src/rpa/boss/handler/send_message.rs
+++ b/src-tauri/src/rpa/boss/handler/send_message.rs
@@ -1,11 +1,11 @@
 use anyhow::anyhow;
-use base64::{engine::general_purpose::STANDARD, Engine as _};
 use rust_drission::{utils::sleep_random_ms, Page};
 use std::{path::Path, time::Duration};
 
 use crate::{
     config::{ReplayResourceType, ReplyResource},
     logger,
+    rpa::common::upload_image_to_file_input,
 };
 
 // 发送文本消息
@@ -27,61 +27,21 @@ pub fn send_text_message(page: &Page, greeting: &str) -> Result<bool, anyhow::Er
     Ok(false)
 }
 
+// 不加 `input[type=file]` 裸兜底：Boss 聊天页还有简历上传框，误命中会把图片塞错地方
+const BOSS_IMAGE_INPUT_SELECTORS: &[&str] = &["input[type='file'][accept*='image']"];
+
 // 发送图片
 pub fn send_image(page: &Page, image_path: &Path) -> Result<bool, anyhow::Error> {
-    let file_data = std::fs::read(image_path)?;
-    let base64_data = STANDARD.encode(&file_data);
+    let outcome = upload_image_to_file_input(page, image_path, BOSS_IMAGE_INPUT_SELECTORS)?;
+    if !outcome.success {
+        logger::warning(format!("Boss 图片上传失败：{}", outcome.message))?;
+        return Ok(false);
+    }
 
-    let ext = image_path
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("png");
-    let mime_type = match ext.to_lowercase().as_str() {
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "webp" => "image/webp",
-        _ => "image/png",
-    };
-
-    let filename = image_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("upload.png");
-
-    let base64_str = format!("data:{};base64,{}", mime_type, base64_data);
-
-    let js = format!(
-        r#"
-(() => {{
-  const base64 = "{}";
-  const input = document.querySelector('input[type="file"][accept*="image"]');
-  if (!input) {{
-    console.error("没找到上传 input");
-    return;
-  }}
-  function base64ToFile(base64, filename) {{
-    const arr = base64.split(',');
-    const mime = arr[0].match(/:(.*?);/)[1];
-    const bstr = atob(arr[1]);
-    let n = bstr.length;
-    const u8arr = new Uint8Array(n);
-    while (n--) {{
-      u8arr[n] = bstr.charCodeAt(n);
-    }}
-    return new File([u8arr], filename, {{ type: mime }});
-  }}
-  const file = base64ToFile(base64, "{}");
-  const dt = new DataTransfer();
-  dt.items.add(file);
-  input.files = dt.files;
-  input.dispatchEvent(new Event("change", {{ bubbles: true }}));
-  console.log("图片已自动上传");
-}})();
-"#,
-        base64_str, filename
-    );
-
-    page.run_js_await(&js)?;
+    logger::info(format!(
+        "Boss 图片已投递到上传控件（selector={} handled={}）",
+        outcome.matched_selector, outcome.handled
+    ))?;
     Ok(true)
 }
 

--- a/src-tauri/src/rpa/boss/handler/sync_chat_history.rs
+++ b/src-tauri/src/rpa/boss/handler/sync_chat_history.rs
@@ -260,6 +260,10 @@ fn upsert_synced_job(
     job_detail_dao::create(JobDetail {
         id: job_id.to_string(),
         platform: "boss".to_string(),
+        source_task_id: None,
+        profile_id: None,
+        profile_name: None,
+        profile_snapshot_id: None,
         title,
         company_name: company_name
             .map(|value| value.trim().to_string())

--- a/src-tauri/src/rpa/boss/handler/sync_chat_history.rs
+++ b/src-tauri/src/rpa/boss/handler/sync_chat_history.rs
@@ -352,127 +352,134 @@ fn collect_current_conversation_keys(
 
 /// 遍历 BOSS 沟通列表并增量同步历史消息。
 pub async fn sync_chat_history() -> Result<ChatHistorySyncResult, anyhow::Error> {
-    browser::with_new_tab(|page| {
-        Box::pin(async move {
-            logger::info("周期间歇：开始同步 BOSS 历史对话")?;
-            page.get(BOSS_CHAT_URL)?;
-            page.wait(".user-list-content", Duration::from_secs(15))?;
-            sleep_random_ms(800, 1200);
+    browser::with_new_tab(|page| Box::pin(async move { sync_chat_history_on_page(page).await }))
+        .await
+}
 
-            // 先在“未读”分类中只扫描标识，绝不点击会话卡片。
-            // 如果无法识别未读分类，为避免误把消息标记为已读，本次同步直接跳过。
-            if !click_label(page, "未读")? {
-                logger::warning("未找到 BOSS 未读分类，为保护未读状态，本次不同步历史对话")?;
-                return Ok(ChatHistorySyncResult::default());
+/// Synchronize BOSS history on a caller-owned task tab.
+pub async fn sync_chat_history_on_page(
+    page: &rust_drission::Page,
+) -> Result<ChatHistorySyncResult, anyhow::Error> {
+    logger::info("周期间歇：开始同步 BOSS 历史对话")?;
+    page.get(BOSS_CHAT_URL)?;
+    page.wait(".user-list-content", Duration::from_secs(15))?;
+    sleep_random_ms(800, 1200);
+
+    // 先在“未读”分类中只扫描标识，绝不点击会话卡片。
+    // 如果无法识别未读分类，为避免误把消息标记为已读，本次同步直接跳过。
+    if !click_label(page, "未读")? {
+        logger::warning("未找到 BOSS 未读分类，为保护未读状态，本次不同步历史对话")?;
+        return Ok(ChatHistorySyncResult::default());
+    }
+    let unread_keys = collect_current_conversation_keys(page)?;
+    logger::info(format!(
+        "检测到未读会话 {} 个，同步时将全部跳过",
+        unread_keys.len()
+    ))?;
+
+    if !click_label(page, "全部")? {
+        logger::warning("未找到 BOSS 全部会话分类，本次不同步历史对话")?;
+        return Ok(ChatHistorySyncResult::default());
+    }
+    scroll_conversation_list(page, true)?;
+
+    let mut result = ChatHistorySyncResult::default();
+    let mut seen = HashSet::new();
+    let mut stagnant_rounds = 0;
+
+    // 会话列表为虚拟滚动列表：不断处理当前已渲染项并向下滚动，
+    // 连续三轮没有新会话时认为到达底部。
+    for _ in 0..50 {
+        if is_job_task_stop_requested() {
+            break;
+        }
+
+        let cards = page.elements(".user-list-content .friend-content")?;
+        let mut discovered = 0;
+        for card in cards {
+            if is_job_task_stop_requested() {
+                break;
             }
-            let unread_keys = collect_current_conversation_keys(page)?;
-            logger::info(format!("检测到未读会话 {} 个，同步时将全部跳过", unread_keys.len()))?;
 
-            if !click_label(page, "全部")? {
-                logger::warning("未找到 BOSS 全部会话分类，本次不同步历史对话")?;
-                return Ok(ChatHistorySyncResult::default());
+            let key = conversation_key(&card.text_content()?);
+            if key.is_empty() || !seen.insert(key.clone()) {
+                continue;
             }
-            scroll_conversation_list(page, true)?;
+            discovered += 1;
+            result.scanned += 1;
 
-            let mut result = ChatHistorySyncResult::default();
-            let mut seen = HashSet::new();
-            let mut stagnant_rounds = 0;
-
-            // 会话列表为虚拟滚动列表：不断处理当前已渲染项并向下滚动，
-            // 连续三轮没有新会话时认为到达底部。
-            for _ in 0..50 {
-                if is_job_task_stop_requested() {
-                    break;
-                }
-
-                let cards = page.elements(".user-list-content .friend-content")?;
-                let mut discovered = 0;
-                for card in cards {
-                    if is_job_task_stop_requested() {
-                        break;
-                    }
-
-                    let key = conversation_key(&card.text_content()?);
-                    if key.is_empty() || !seen.insert(key.clone()) {
-                        continue;
-                    }
-                    discovered += 1;
-                    result.scanned += 1;
-
-                    // 第一层：未读分类快照；第二层：点击前检查常见未读标记。
-                    // 任一命中都跳过，避免同步动作改变未读状态。
-                    let has_unread_marker = card
+            // 第一层：未读分类快照；第二层：点击前检查常见未读标记。
+            // 任一命中都跳过，避免同步动作改变未读状态。
+            let has_unread_marker = card
                         .element(
                             "[class*='unread'], .badge, .badge-count, .unread-count, .red-dot, .notice-badge",
                         )?
                         .is_some();
-                    if unread_keys.contains(&key) || has_unread_marker {
-                        result.skipped_unread += 1;
-                        continue;
-                    }
-
-                    let history_listener = page.listen_url("zpchat/geek/historyMsg")?;
-                    let boss_data_listener = page.listen_url("zpchat/geek/getBossData")?;
-                    card.click()?;
-                    sleep_random_ms(350, 600);
-
-                    let boss_data_body = boss_data_listener
-                        .wait(Duration::from_secs(6))
-                        .ok()
-                        .flatten()
-                        .and_then(|packet| packet.body)
-                        .and_then(|body| String::from_utf8(body).ok());
-                    let job_id = boss_data_body
-                        .as_deref()
-                        .and_then(parse_encrypt_job_id);
-
-                    let history_body = history_listener
-                        .wait(Duration::from_secs(8))
-                        .ok()
-                        .flatten()
-                        .and_then(|packet| packet.body)
-                        .and_then(|body| String::from_utf8(body).ok());
-
-                    let (Some(job_id), Some(history_body)) = (job_id, history_body) else {
-                        logger::warning("同步会话时未获取到 jobId 或 historyMsg，已跳过")?;
-                        continue;
-                    };
-
-                    let messages = parse_chat_messages(&history_body)
-                        .context("解析周期间歇历史对话失败")?;
-                    let dom_snapshot = extract_job_snapshot_from_dom(page);
-                    let api_snapshot = merge_snapshot(
-                        boss_data_body
-                            .as_deref()
-                            .map(parse_job_snapshot)
-                            .unwrap_or_default(),
-                        parse_job_snapshot(&history_body),
-                    );
-                    let snapshot = merge_snapshot(dom_snapshot, api_snapshot);
-                    match upsert_synced_job(&job_id, snapshot, &messages)? {
-                        JobSyncChange::Inserted => result.jobs_inserted += 1,
-                        JobSyncChange::Updated => result.jobs_updated += 1,
-                        JobSyncChange::None => {}
-                    }
-                    let saved = chat_message_dao::upsert_incremental(&job_id, &messages)?;
-                    result.conversations += 1;
-                    result.inserted += saved.inserted;
-                    result.updated += saved.updated;
-                }
-
-                if discovered == 0 {
-                    stagnant_rounds += 1;
-                    if stagnant_rounds >= 3 {
-                        break;
-                    }
-                } else {
-                    stagnant_rounds = 0;
-                }
-
-                scroll_conversation_list(page, false)?;
+            if unread_keys.contains(&key) || has_unread_marker {
+                result.skipped_unread += 1;
+                continue;
             }
 
-            logger::info(format!(
+            let history_listener = page.listen_url("zpchat/geek/historyMsg")?;
+            let boss_data_listener = page.listen_url("zpchat/geek/getBossData")?;
+            card.click()?;
+            sleep_random_ms(350, 600);
+
+            let boss_data_body = boss_data_listener
+                .wait(Duration::from_secs(6))
+                .ok()
+                .flatten()
+                .and_then(|packet| packet.body)
+                .and_then(|body| String::from_utf8(body).ok());
+            let job_id = boss_data_body.as_deref().and_then(parse_encrypt_job_id);
+
+            let history_body = history_listener
+                .wait(Duration::from_secs(8))
+                .ok()
+                .flatten()
+                .and_then(|packet| packet.body)
+                .and_then(|body| String::from_utf8(body).ok());
+
+            let (Some(job_id), Some(history_body)) = (job_id, history_body) else {
+                logger::warning("同步会话时未获取到 jobId 或 historyMsg，已跳过")?;
+                continue;
+            };
+
+            let messages =
+                parse_chat_messages(&history_body).context("解析周期间歇历史对话失败")?;
+            let dom_snapshot = extract_job_snapshot_from_dom(page);
+            let api_snapshot = merge_snapshot(
+                boss_data_body
+                    .as_deref()
+                    .map(parse_job_snapshot)
+                    .unwrap_or_default(),
+                parse_job_snapshot(&history_body),
+            );
+            let snapshot = merge_snapshot(dom_snapshot, api_snapshot);
+            match upsert_synced_job(&job_id, snapshot, &messages)? {
+                JobSyncChange::Inserted => result.jobs_inserted += 1,
+                JobSyncChange::Updated => result.jobs_updated += 1,
+                JobSyncChange::None => {}
+            }
+            let saved = chat_message_dao::upsert_incremental(&job_id, &messages)?;
+            result.conversations += 1;
+            result.inserted += saved.inserted;
+            result.updated += saved.updated;
+        }
+
+        if discovered == 0 {
+            stagnant_rounds += 1;
+            if stagnant_rounds >= 3 {
+                break;
+            }
+        } else {
+            stagnant_rounds = 0;
+        }
+
+        scroll_conversation_list(page, false)?;
+    }
+
+    logger::info(format!(
                 "BOSS 历史对话同步完成：扫描 {} 个，同步 {} 个，跳过未读 {} 个，新增岗位 {} 个，更新岗位 {} 个，新增消息 {} 条，更新消息 {} 条",
                 result.scanned,
                 result.conversations,
@@ -482,10 +489,7 @@ pub async fn sync_chat_history() -> Result<ChatHistorySyncResult, anyhow::Error>
                 result.inserted,
                 result.updated
             ))?;
-            Ok(result)
-        })
-    })
-    .await
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/rpa/common.rs
+++ b/src-tauri/src/rpa/common.rs
@@ -107,13 +107,11 @@ pub fn upload_image_to_file_input(
     })
 }
 
-fn build_upload_image_script(
-    input_selectors: &[&str],
-    data_url: &str,
-    filename: &str,
-) -> String {
-    let selectors_json = serde_json::to_string(input_selectors).unwrap_or_else(|_| "[]".to_string());
-    let filename_json = serde_json::to_string(filename).unwrap_or_else(|_| "\"upload.png\"".to_string());
+fn build_upload_image_script(input_selectors: &[&str], data_url: &str, filename: &str) -> String {
+    let selectors_json =
+        serde_json::to_string(input_selectors).unwrap_or_else(|_| "[]".to_string());
+    let filename_json =
+        serde_json::to_string(filename).unwrap_or_else(|_| "\"upload.png\"".to_string());
 
     format!(
         r#"
@@ -184,7 +182,11 @@ mod tests {
 
     #[test]
     fn upload_script_escapes_filename_with_quotes() {
-        let script = build_upload_image_script(&["input[type='file']"], "data:image/png;base64,AA", "a\"b.png");
+        let script = build_upload_image_script(
+            &["input[type='file']"],
+            "data:image/png;base64,AA",
+            "a\"b.png",
+        );
 
         assert!(script.contains(r#"const filename = "a\"b.png""#));
     }

--- a/src-tauri/src/rpa/common.rs
+++ b/src-tauri/src/rpa/common.rs
@@ -1,3 +1,8 @@
+use std::path::Path;
+
+use anyhow::anyhow;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use rust_drission::Page;
 use serde::{Deserialize, Serialize};
 
 use super::run_flow::PlatformKind;
@@ -21,4 +26,166 @@ pub struct ChatMessage {
     pub text: String,
     pub time: i64,
     pub from_name: String,
+}
+
+/// 图片投递到上传控件的结果。
+#[derive(Debug, Clone, Default)]
+pub struct ImageUploadOutcome {
+    pub success: bool,
+    pub message: String,
+    /// 实际命中的选择器，便于排查各平台 DOM 变化
+    pub matched_selector: String,
+    /// 命中 input 的 accept 属性原文
+    pub accept: String,
+    /// 前端上传组件是否确实接管了 change 事件（input 被重建或 files 被清空）
+    pub handled: bool,
+}
+
+/// 把本地图片写入页面的 file input 并派发 change 事件。
+///
+/// 各平台上传控件的属性差异很大：Boss 是 `accept="image/*"`，猎聘是
+/// `accept="jpg, jpeg, png, bmp"`（不含 image 字样），所以选择器不能写死，
+/// 由调用方按优先级传入，命中第一个可用的即停止。
+pub fn upload_image_to_file_input(
+    page: &Page,
+    image_path: &Path,
+    input_selectors: &[&str],
+) -> Result<ImageUploadOutcome, anyhow::Error> {
+    let file_data = std::fs::read(image_path)
+        .map_err(|e| anyhow!("读取图片失败 {}: {}", image_path.display(), e))?;
+    let base64_data = STANDARD.encode(&file_data);
+
+    let extension = image_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("png")
+        .to_ascii_lowercase();
+    let mime_type = match extension.as_str() {
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "bmp" => "image/bmp",
+        _ => "image/png",
+    };
+    let filename = image_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("upload.png");
+
+    let script = build_upload_image_script(
+        input_selectors,
+        &format!("data:{};base64,{}", mime_type, base64_data),
+        filename,
+    );
+    let value = page.run_js_await(&script)?;
+    let result = value.get("value").cloned().unwrap_or(value);
+
+    Ok(ImageUploadOutcome {
+        success: result
+            .get("success")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        message: result
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        matched_selector: result
+            .get("matchedSelector")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        accept: result
+            .get("accept")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        handled: result
+            .get("handled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    })
+}
+
+fn build_upload_image_script(
+    input_selectors: &[&str],
+    data_url: &str,
+    filename: &str,
+) -> String {
+    let selectors_json = serde_json::to_string(input_selectors).unwrap_or_else(|_| "[]".to_string());
+    let filename_json = serde_json::to_string(filename).unwrap_or_else(|_| "\"upload.png\"".to_string());
+
+    format!(
+        r#"
+        (async () => {{
+            const selectors = {selectors_json};
+            const dataUrl = "{data_url}";
+            const filename = {filename_json};
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const usable = (el) => el instanceof HTMLInputElement && el.type === "file" && !el.disabled;
+
+            let input = null;
+            let matchedSelector = "";
+            for (const selector of selectors) {{
+                const found = Array.from(document.querySelectorAll(selector)).find(usable);
+                if (found) {{
+                    input = found;
+                    matchedSelector = selector;
+                    break;
+                }}
+            }}
+            if (!input) {{
+                return {{ success: false, message: "未找到图片上传输入框", matchedSelector: "" }};
+            }}
+
+            const accept = input.getAttribute("accept") || "";
+            const parts = dataUrl.split(",");
+            const mime = (parts[0].match(/:(.*?);/) || [])[1] || "image/png";
+            const binary = atob(parts[1]);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i += 1) {{
+                bytes[i] = binary.charCodeAt(i);
+            }}
+
+            const transfer = new DataTransfer();
+            transfer.items.add(new File([bytes], filename, {{ type: mime }}));
+            input.files = transfer.files;
+            // file input 不受 React value tracker 影响，原生 change 即可触发 onChange
+            input.dispatchEvent(new Event("change", {{ bubbles: true }}));
+            await sleep(600);
+
+            // rc-upload 接管后会重建 input（uid 变化）或清空已选文件，以此判断事件是否被消费
+            const handled = !document.contains(input) || input.files.length === 0 || !input.value;
+            return {{ success: true, message: "已投递到上传控件", matchedSelector, accept, handled }};
+        }})()
+        "#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upload_script_builds_file_from_data_url_and_dispatches_change() {
+        let script = build_upload_image_script(
+            &[".im-ui-upload-container input[type='file']"],
+            "data:image/png;base64,AAAA",
+            "hello.png",
+        );
+
+        assert!(script.contains(".im-ui-upload-container input[type='file']"));
+        assert!(script.contains("new DataTransfer()"));
+        assert!(script.contains("input.files = transfer.files"));
+        assert!(script.contains("new Event(\"change\", { bubbles: true })"));
+        assert!(script.contains("未找到图片上传输入框"));
+        assert!(script.contains("const handled ="));
+    }
+
+    #[test]
+    fn upload_script_escapes_filename_with_quotes() {
+        let script = build_upload_image_script(&["input[type='file']"], "data:image/png;base64,AA", "a\"b.png");
+
+        assert!(script.contains(r#"const filename = "a\"b.png""#));
+    }
 }

--- a/src-tauri/src/rpa/liepin/handler/login_check.rs
+++ b/src-tauri/src/rpa/liepin/handler/login_check.rs
@@ -1,7 +1,15 @@
-use crate::{browser, rpa::liepin::LIEPIN_SITE_URL};
+use crate::{
+    browser, logger,
+    rpa::liepin::{LIEPIN_USER_HOME_URL, LIEPIN_USER_PROPERTY_API},
+};
 use anyhow::anyhow;
-use rust_drission::utils::sleep_random_ms;
+use rust_drission::{utils::sleep_random_ms, ChromiumPage};
 use serde_json::{json, Value};
+
+/// 页面就绪判定的正文长度下限。猎聘页面渲染完成后正文远超这个量级，
+/// 低于它基本可以认定 DOM 还没出来。
+const MIN_READY_TEXT_LENGTH: i64 = 80;
+const API_PROBE_MAX_ATTEMPTS: usize = 3;
 
 pub async fn login_check() -> Result<Value, anyhow::Error> {
     let verify_result =
@@ -11,42 +19,320 @@ pub async fn login_check() -> Result<Value, anyhow::Error> {
     })))
 }
 
-fn verify_login(page: &rust_drission::ChromiumPage) -> Result<(), anyhow::Error> {
-    if !page.url()?.contains("liepin.com") {
-        page.get(LIEPIN_SITE_URL)?;
-        sleep_random_ms(1200, 2000);
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoginState {
+    LoggedIn,
+    LoggedOut,
+    Unknown,
+}
 
-    let login_state = page.run_js_await(
-        r#"
-        (() => {
-            const text = document.body ? document.body.innerText : "";
-            const hasLoginText = /登录|扫码|验证码/.test(text);
-            const hasUserSignal = [
-                ".user-info",
-                ".user-name",
-                ".header-user",
-                ".personal-center",
-                "a[href*='resume']",
-                "a[href*='message']"
-            ].some((selector) => document.querySelector(selector));
-            return hasUserSignal && !hasLoginText;
-        })()
-        "#,
-    )?;
+/// 用户信息接口的判定结果。
+///
+/// 只在拿到强证据时下结论：接口确认身份即已登录，401/403 即未登录，
+/// 其余（CORS 被拦、断网、5xx、返回体看不懂）一律 Unknown 交给页面特征兜底，
+/// 否则一次网络抖动就会把已登录的会话踢去扫码。
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ApiVerdict {
+    LoggedIn(String),
+    LoggedOut(String),
+    Unknown(String),
+}
 
-    let success = login_state
-        .get("value")
-        .and_then(Value::as_bool)
-        .or_else(|| login_state.as_bool())
-        .unwrap_or(false);
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ApiResponse {
+    status: i64,
+    body: String,
+    error: String,
+}
 
-    if success {
-        Ok(())
-    } else {
-        Err(anyhow!("未检测到猎聘登录态"))
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct LoginProbe {
+    ready: bool,
+    text_length: i64,
+    on_login_page: bool,
+    has_login_entry: bool,
+    has_user_signal: bool,
+}
+
+impl LoginProbe {
+    fn state(&self) -> LoginState {
+        // 页面没渲染完时所有信号都是空的，这时判“未登录”会把正在刷新的已登录会话
+        // 直接拽去扫码页，所以必须先归为未知。
+        if !self.ready || self.text_length < MIN_READY_TEXT_LENGTH {
+            return LoginState::Unknown;
+        }
+        if self.on_login_page || self.has_login_entry {
+            return LoginState::LoggedOut;
+        }
+        if self.has_user_signal {
+            return LoginState::LoggedIn;
+        }
+        LoginState::Unknown
     }
 }
+
+fn verify_login(page: &ChromiumPage) -> Result<(), anyhow::Error> {
+    // 接口的 Access-Control-Allow-Origin 精确等于 https://c.liepin.com，
+    // 站在 www.liepin.com 上发请求会被浏览器拦掉，所以先落到候选人端主页。
+    if !page.url()?.contains("c.liepin.com") {
+        page.get(LIEPIN_USER_HOME_URL)?;
+    }
+    // 不论有没有发生导航都要等：页面刷新时 URL 已经是 liepin.com 但 DOM 还是空的
+    let ready = wait_until_page_ready(page)?;
+
+    let mut last_reason = String::new();
+    for attempt in 0..API_PROBE_MAX_ATTEMPTS {
+        match probe_via_user_api(page)? {
+            ApiVerdict::LoggedIn(user_name) => {
+                // 日志写失败不能影响登录判定，否则又多一条误判路径
+                let _ = logger::info(format!("猎聘登录态已确认（当前账号：{}）", user_name));
+                return Ok(());
+            }
+            ApiVerdict::LoggedOut(reason) => {
+                return Err(anyhow!("猎聘登录态已失效（{}），需要重新扫码", reason));
+            }
+            ApiVerdict::Unknown(reason) => {
+                // 重试过程不逐次记录，只有最终没结论时才汇报一次
+                last_reason = reason;
+                if attempt + 1 < API_PROBE_MAX_ATTEMPTS {
+                    sleep_random_ms(1000, 1600);
+                }
+            }
+        }
+    }
+
+    // 接口不可用（改版、被风控、离线）时降级到页面特征，不至于整个功能瘫掉
+    let _ = logger::warning(format!(
+        "猎聘用户接口无法确认登录态（{}），改用页面特征判断",
+        last_reason
+    ));
+    let probe = probe_login_state(page)?;
+    match probe.state() {
+        LoginState::LoggedIn => Ok(()),
+        LoginState::LoggedOut => Err(anyhow!("页面停留在猎聘登录入口，需要重新扫码")),
+        LoginState::Unknown => Err(anyhow!(
+            "无法确认登录态（接口：{}；页面就绪={} 正文长度={}）",
+            last_reason,
+            ready && probe.ready,
+            probe.text_length
+        )),
+    }
+}
+
+fn probe_via_user_api(page: &ChromiumPage) -> Result<ApiVerdict, anyhow::Error> {
+    let value = page.run_js_await(&build_user_api_script())?;
+    let result = value.get("value").cloned().unwrap_or(value);
+
+    Ok(classify_api_response(&ApiResponse {
+        status: result
+            .get("status")
+            .and_then(Value::as_i64)
+            .unwrap_or_default(),
+        body: result
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        error: result
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+    }))
+}
+
+fn classify_api_response(response: &ApiResponse) -> ApiVerdict {
+    // fetch 抛异常（CORS 被拦、断网）时拿不到状态码
+    if response.status == 0 {
+        return ApiVerdict::Unknown(if response.error.is_empty() {
+            "请求未拿到响应".to_string()
+        } else {
+            format!("请求失败：{}", response.error)
+        });
+    }
+    if response.status == 401 || response.status == 403 {
+        return ApiVerdict::LoggedOut(format!("接口返回 {}", response.status));
+    }
+    if !(200..300).contains(&response.status) {
+        return ApiVerdict::Unknown(format!("接口返回 HTTP {}", response.status));
+    }
+
+    let Ok(body) = serde_json::from_str::<Value>(&response.body) else {
+        return ApiVerdict::Unknown("接口响应不是合法 JSON".to_string());
+    };
+
+    let user_name = body
+        .pointer("/data/userName")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if body.get("flag").and_then(Value::as_i64) == Some(1) && !user_name.is_empty() {
+        return ApiVerdict::LoggedIn(user_name);
+    }
+
+    // flag 不为 1 也可能是接口改版或业务异常，只有出现明确的登录关键字才判失效
+    let serialized = response.body.to_lowercase();
+    if serialized.contains("not login")
+        || serialized.contains("unlogin")
+        || serialized.contains("not_login")
+        || response.body.contains("未登录")
+        || response.body.contains("重新登录")
+    {
+        return ApiVerdict::LoggedOut("接口提示登录态失效".to_string());
+    }
+
+    ApiVerdict::Unknown("接口未返回可识别的用户信息".to_string())
+}
+
+fn build_user_api_script() -> String {
+    format!(
+        r#"
+        (async () => {{
+            const readCookie = (name) => {{
+                const matched = document.cookie.match(new RegExp("(^|;\\s*)" + name + "=([^;]*)"));
+                return matched ? decodeURIComponent(matched[2]) : "";
+            }};
+            // XSRF-TOKEN 每个会话都不同，必须现读现用
+            const xsrfToken = readCookie("XSRF-TOKEN");
+            const traceId = (window.crypto && crypto.randomUUID)
+                ? crypto.randomUUID()
+                : "trace-" + performance.now().toString(36);
+
+            const headers = {{
+                "Accept": "application/json, text/plain, */*",
+                "Content-Type": "application/x-www-form-urlencoded",
+                "X-Client-Type": "web",
+                "X-Requested-With": "XMLHttpRequest",
+                "X-Fscp-Version": "1.1",
+                "X-Fscp-Std-Info": '{{"client_id": "40106"}}',
+                "X-Fscp-Trace-Id": traceId,
+                "X-Fscp-Bi-Stat": JSON.stringify({{ location: location.href }})
+            }};
+            if (xsrfToken) {{
+                headers["X-XSRF-TOKEN"] = xsrfToken;
+            }}
+
+            try {{
+                const response = await fetch("{LIEPIN_USER_PROPERTY_API}", {{
+                    method: "POST",
+                    credentials: "include",
+                    headers,
+                    body: ""
+                }});
+                const body = await response.text();
+                return {{ status: response.status, body, error: "" }};
+            }} catch (error) {{
+                return {{ status: 0, body: "", error: String((error && error.message) || error) }};
+            }}
+        }})()
+        "#
+    )
+}
+
+/// 等到 DOM 真正渲染出来，最多约 12 秒。返回是否等到就绪。
+fn wait_until_page_ready(page: &ChromiumPage) -> Result<bool, anyhow::Error> {
+    let value = page.run_js_await(&build_wait_page_ready_script())?;
+    let result = value.get("value").cloned().unwrap_or(value);
+    Ok(result
+        .get("ready")
+        .and_then(Value::as_bool)
+        .unwrap_or(false))
+}
+
+fn build_wait_page_ready_script() -> String {
+    format!(
+        r#"
+        (async () => {{
+            const minTextLength = {MIN_READY_TEXT_LENGTH};
+            const stepMs = 300;
+            const maxAttempts = 40;
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            for (let attempt = 0; attempt < maxAttempts; attempt += 1) {{
+                const text = document.body ? (document.body.innerText || "") : "";
+                if (document.readyState === "complete" && text.trim().length >= minTextLength) {{
+                    return {{ ready: true, waitedMs: attempt * stepMs }};
+                }}
+                await sleep(stepMs);
+            }}
+            return {{ ready: false, waitedMs: maxAttempts * stepMs }};
+        }})()
+        "#
+    )
+}
+
+fn probe_login_state(page: &ChromiumPage) -> Result<LoginProbe, anyhow::Error> {
+    let value = page.run_js_await(PROBE_LOGIN_STATE_SCRIPT)?;
+    let result = value.get("value").cloned().unwrap_or(value);
+
+    Ok(LoginProbe {
+        ready: result
+            .get("ready")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        text_length: result
+            .get("textLength")
+            .and_then(Value::as_i64)
+            .unwrap_or_default(),
+        on_login_page: result
+            .get("onLoginPage")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        has_login_entry: result
+            .get("hasLoginEntry")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        has_user_signal: result
+            .get("hasUserSignal")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    })
+}
+
+const PROBE_LOGIN_STATE_SCRIPT: &str = r#"
+    (() => {
+        const text = document.body ? (document.body.innerText || "") : "";
+        const href = location.href || "";
+        const visible = (el) => {
+            if (!el) return false;
+            const rect = el.getBoundingClientRect();
+            const style = window.getComputedStyle(el);
+            return rect.width > 0 && rect.height > 0
+                && style.visibility !== "hidden"
+                && style.display !== "none";
+        };
+
+        // 登录页有独立 URL（/simple-login/），比在正文里搜“登录”二字可靠得多：
+        // 已登录首页的页脚、帮助入口同样会出现“登录”。
+        const onLoginPage = /\/(simple-)?login|\/passport|\/account\/login/i.test(href);
+        const hasLoginEntry = Boolean(
+            document.querySelector("input[type='password']")
+            || document.querySelector("img[class*='qrcode-img']")
+            || document.querySelector("img[src*='qrcode']:not([src*='qrcode-btn'])")
+            || Array
+                .from(document.querySelectorAll("a[href*='login'], [class*='login-btn'], [class*='btn-login']"))
+                .some(visible)
+            || /扫码登录|手机号登录|验证码登录|密码登录/.test(text)
+        );
+        const hasUserSignal = [
+            ".user-info",
+            ".user-name",
+            ".header-user",
+            ".personal-center",
+            "a[href*='resume']",
+            "a[href*='message']"
+        ].some((selector) => document.querySelector(selector));
+
+        return {
+            ready: document.readyState === "complete",
+            textLength: text.trim().length,
+            onLoginPage,
+            hasLoginEntry,
+            hasUserSignal
+        };
+    })()
+"#;
 
 fn build_login_check_output(verify_result: Result<(), anyhow::Error>) -> serde_json::Value {
     match verify_result {
@@ -70,4 +356,196 @@ fn summarize_error(error: &anyhow::Error) -> String {
         .next()
         .map(str::to_string)
         .unwrap_or(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn api(status: i64, body: &str) -> ApiResponse {
+        ApiResponse {
+            status,
+            body: body.to_string(),
+            error: String::new(),
+        }
+    }
+
+    fn probe(ready: bool, text_length: i64) -> LoginProbe {
+        LoginProbe {
+            ready,
+            text_length,
+            ..LoginProbe::default()
+        }
+    }
+
+    #[test]
+    fn real_user_property_response_is_recognized_as_logged_in() {
+        let body = r#"{"flag":1,"data":{"userName":"李炳桦","sexName":"男","resId":"9b27608d8321R47b876959abe","userShowName":"李先生"}}"#;
+
+        assert_eq!(
+            classify_api_response(&api(200, body)),
+            ApiVerdict::LoggedIn("李炳桦".to_string())
+        );
+    }
+
+    #[test]
+    fn unauthorized_status_means_logged_out() {
+        assert!(matches!(
+            classify_api_response(&api(401, "")),
+            ApiVerdict::LoggedOut(_)
+        ));
+        assert!(matches!(
+            classify_api_response(&api(403, "")),
+            ApiVerdict::LoggedOut(_)
+        ));
+    }
+
+    #[test]
+    fn cors_or_network_failure_is_unknown_not_logged_out() {
+        // 站错域名时浏览器直接拦掉 fetch，这种情况绝不能判成未登录
+        let blocked = ApiResponse {
+            status: 0,
+            body: String::new(),
+            error: "Failed to fetch".to_string(),
+        };
+
+        assert!(matches!(
+            classify_api_response(&blocked),
+            ApiVerdict::Unknown(_)
+        ));
+    }
+
+    #[test]
+    fn server_error_and_unparsable_body_are_unknown() {
+        assert!(matches!(
+            classify_api_response(&api(502, "<html>bad gateway</html>")),
+            ApiVerdict::Unknown(_)
+        ));
+        assert!(matches!(
+            classify_api_response(&api(200, "not json")),
+            ApiVerdict::Unknown(_)
+        ));
+    }
+
+    #[test]
+    fn flag_success_without_user_name_is_unknown() {
+        // 接口改版可能 flag 仍为 1 但结构变了，此时不下结论、交给页面特征
+        assert!(matches!(
+            classify_api_response(&api(200, r#"{"flag":1,"data":{}}"#)),
+            ApiVerdict::Unknown(_)
+        ));
+        assert!(matches!(
+            classify_api_response(&api(200, r#"{"flag":1,"data":null}"#)),
+            ApiVerdict::Unknown(_)
+        ));
+    }
+
+    #[test]
+    fn explicit_login_hint_in_body_means_logged_out() {
+        assert!(matches!(
+            classify_api_response(&api(200, r#"{"flag":0,"message":"用户未登录"}"#)),
+            ApiVerdict::LoggedOut(_)
+        ));
+        assert!(matches!(
+            classify_api_response(&api(200, r#"{"flag":0,"code":"NOT_LOGIN"}"#)),
+            ApiVerdict::LoggedOut(_)
+        ));
+    }
+
+    #[test]
+    fn unrecognized_business_failure_is_unknown() {
+        // 单纯 flag != 1 不足以判定未登录，可能只是接口自身异常
+        assert!(matches!(
+            classify_api_response(&api(200, r#"{"flag":0,"message":"系统繁忙"}"#)),
+            ApiVerdict::Unknown(_)
+        ));
+    }
+
+    #[test]
+    fn api_script_targets_candidate_api_with_credentials_and_fresh_xsrf_token() {
+        let script = build_user_api_script();
+
+        assert!(script.contains(LIEPIN_USER_PROPERTY_API));
+        assert!(script.contains("credentials: \"include\""));
+        assert!(script.contains("readCookie(\"XSRF-TOKEN\")"));
+        assert!(script.contains("\"X-Client-Type\": \"web\""));
+        assert!(script.contains(r#"'{"client_id": "40106"}'"#));
+        assert!(script.contains("method: \"POST\""));
+    }
+
+    #[test]
+    fn page_still_loading_is_unknown_instead_of_logged_out() {
+        // 刷新中：URL 已经是 liepin.com 但 DOM 为空，此时不能判未登录
+        assert_eq!(probe(false, 0).state(), LoginState::Unknown);
+        assert_eq!(probe(true, 0).state(), LoginState::Unknown);
+        assert_eq!(
+            probe(true, MIN_READY_TEXT_LENGTH - 1).state(),
+            LoginState::Unknown
+        );
+    }
+
+    #[test]
+    fn ready_page_without_any_signal_is_unknown_not_logged_out() {
+        assert_eq!(probe(true, 2000).state(), LoginState::Unknown);
+    }
+
+    #[test]
+    fn login_page_or_visible_login_entry_means_logged_out() {
+        let on_login_page = LoginProbe {
+            ready: true,
+            text_length: 2000,
+            on_login_page: true,
+            ..LoginProbe::default()
+        };
+        let with_entry = LoginProbe {
+            ready: true,
+            text_length: 2000,
+            has_login_entry: true,
+            ..LoginProbe::default()
+        };
+
+        assert_eq!(on_login_page.state(), LoginState::LoggedOut);
+        assert_eq!(with_entry.state(), LoginState::LoggedOut);
+    }
+
+    #[test]
+    fn user_signal_on_ready_page_means_logged_in() {
+        let logged_in = LoginProbe {
+            ready: true,
+            text_length: 2000,
+            has_user_signal: true,
+            ..LoginProbe::default()
+        };
+
+        assert_eq!(logged_in.state(), LoginState::LoggedIn);
+    }
+
+    #[test]
+    fn login_page_wins_over_user_signal() {
+        let conflicting = LoginProbe {
+            ready: true,
+            text_length: 2000,
+            on_login_page: true,
+            has_user_signal: true,
+            ..LoginProbe::default()
+        };
+
+        assert_eq!(conflicting.state(), LoginState::LoggedOut);
+    }
+
+    #[test]
+    fn probe_script_detects_login_page_by_url_not_by_body_keyword() {
+        assert!(PROBE_LOGIN_STATE_SCRIPT.contains("simple-login"));
+        assert!(PROBE_LOGIN_STATE_SCRIPT.contains("location.href"));
+        assert!(!PROBE_LOGIN_STATE_SCRIPT.contains("/登录|扫码|验证码/"));
+    }
+
+    #[test]
+    fn wait_script_polls_until_dom_actually_rendered() {
+        let script = build_wait_page_ready_script();
+
+        assert!(script.contains("document.readyState === \"complete\""));
+        assert!(script.contains("const minTextLength = 80"));
+        assert!(script.contains("maxAttempts = 40"));
+    }
 }

--- a/src-tauri/src/rpa/liepin/handler/mod.rs
+++ b/src-tauri/src/rpa/liepin/handler/mod.rs
@@ -5,5 +5,5 @@ mod reply_unread;
 
 pub use login::login;
 pub use login_check::login_check;
-pub use position_say_hello::position_say_hello;
-pub use reply_unread::reply_unread;
+pub use position_say_hello::{position_say_hello, position_say_hello_on_page};
+pub use reply_unread::{reply_unread, reply_unread_on_page};

--- a/src-tauri/src/rpa/liepin/handler/position_say_hello.rs
+++ b/src-tauri/src/rpa/liepin/handler/position_say_hello.rs
@@ -580,7 +580,7 @@ async fn greet_job(
 
         let resources = build_greet_resources(&config, &job).await?;
         send_resources(&page, resources)?;
-        save_job_detail(&job);
+        save_job_detail(&job, &config);
         logger::info(format!("猎聘 {} 初次沟通成功", job.title))?;
         Ok(())
     }
@@ -1081,11 +1081,16 @@ fn build_send_text_script(text: &str) -> String {
     )
 }
 
-fn save_job_detail(job: &RpaJob) {
+fn save_job_detail(job: &RpaJob, config: &AppRuntimeConfig) {
     let now = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let active = config.active_job_profile.as_ref();
     let job_detail = JobDetail {
         id: format!("liepin:{}", job.platform_job_id),
         platform: "liepin".to_string(),
+        source_task_id: crate::rpa::run_flow::current_job_task_id(),
+        profile_id: active.map(|profile| profile.id.clone()),
+        profile_name: active.map(|profile| profile.name.clone()),
+        profile_snapshot_id: active.map(|profile| profile.snapshot_id.clone()),
         title: job.title.clone(),
         company_name: job.company_name.clone(),
         detail: job.detail.clone(),

--- a/src-tauri/src/rpa/liepin/handler/position_say_hello.rs
+++ b/src-tauri/src/rpa/liepin/handler/position_say_hello.rs
@@ -23,124 +23,129 @@ use urlencoding::encode;
 
 pub async fn position_say_hello(config: &AppRuntimeConfig) -> Result<(), anyhow::Error> {
     let config = config.clone();
-    let search_url = build_job_search_url(&config);
-
-    browser::with_browser(|page| {
-        Box::pin(async move {
-            let mut processed_job_ids: HashSet<String> = job_detail_dao::list()
-                .unwrap_or_default()
-                .into_iter()
-                .map(|j| j.id)
-                .collect();
-            logger::info(format!(
-                "猎聘本地已存储 {} 条岗位记录",
-                processed_job_ids.len()
-            ))?;
-
-            let mut seen_job_ids: HashSet<String> = HashSet::new();
-
-            logger::info(format!("正在打开猎聘职位搜索页: {}", search_url))?;
-            page.get(&search_url)?;
-            sleep_random_ms(1200, 2000);
-            apply_liepin_filters(page, &config)?;
-            sleep_random_ms(1200, 1800);
-
-            loop {
-                if is_job_task_stop_requested() {
-                    logger::info("猎聘求职任务已结束")?;
-                    return Ok(());
-                }
-
-                let jobs = collect_jobs(page)?;
-                if jobs.is_empty() {
-                    logger::info("猎聘暂无可处理岗位")?;
-                    return Ok(());
-                }
-
-                logger::info(format!("猎聘当前加载到{}条岗位", jobs.len()))?;
-                let mut stats = RoundStats::default();
-                for job in jobs {
-                    if is_job_task_stop_requested() {
-                        logger::info("猎聘求职任务已结束")?;
-                        return Ok(());
-                    }
-
-                    stats.scanned += 1;
-                    let db_id = format!("liepin:{}", job.platform_job_id);
-                    if processed_job_ids.contains(&db_id)
-                        || processed_job_ids.contains(&job.platform_job_id)
-                        || seen_job_ids.contains(&job.platform_job_id)
-                    {
-                        // 逐条打会把日志刷满，这里只计数，本页结束时汇总
-                        stats.skipped_processed += 1;
-                        continue;
-                    }
-                    seen_job_ids.insert(job.platform_job_id.clone());
-
-                    let filter_decision = verify::filter_decision(&job, &config);
-                    if !filter_decision.matched {
-                        stats.skipped_rule += 1;
-                        continue;
-                    }
-
-                    logger::info(format!(
-                        "猎聘处理岗位：{} - {}",
-                        job.title, job.company_name
-                    ))?;
-                    if config.job_filter_config.enable_semantic_filter {
-                        match crate::llm::evaluate_job_match(&config, &job).await {
-                            Ok(decision) if decision.matched => logger::info(format!(
-                                "猎聘 AI 岗位复核通过（{}分）：{}",
-                                decision.score, decision.reason
-                            ))?,
-                            Ok(decision) => {
-                                stats.skipped_ai += 1;
-                                logger::info(format!(
-                                    "猎聘 AI 岗位复核未通过，跳过（{}分）：{}",
-                                    decision.score, decision.reason
-                                ))?;
-                                continue;
-                            }
-                            Err(error) => {
-                                stats.skipped_ai += 1;
-                                logger::warning(format!(
-                                    "猎聘 AI 岗位复核失败，为避免误投已跳过：{}",
-                                    error
-                                ))?;
-                                continue;
-                            }
-                        }
-                    }
-
-                    match greet_job(page, job.clone(), config.clone()).await {
-                        Ok(()) => {
-                            stats.greeted += 1;
-                            processed_job_ids.insert(format!("liepin:{}", job.platform_job_id));
-                            processed_job_ids.insert(job.platform_job_id.clone());
-                        }
-                        Err(error) => {
-                            stats.greet_failed += 1;
-                            logger::warning(greet_failure_message(
-                                &job.title,
-                                &job.company_name,
-                                &error,
-                            ))?;
-                            continue;
-                        }
-                    }
-                    sleep_random_ms(2500, 4500);
-                }
-
-                logger::info(stats.summary())?;
-
-                if !scroll_next(page)? {
-                    logger::info("猎聘岗位列表已触底")?;
-                    return Ok(());
-                }
-            }
-        })
+    browser::with_browser(|connection| {
+        Box::pin(
+            async move { position_say_hello_on_page(connection, connection.tab(), &config).await },
+        )
     })
     .await
+}
+
+/// Run the Liepin job-hunting flow on the task-owned main tab.
+pub async fn position_say_hello_on_page(
+    connection: &ChromiumPage,
+    page: &Page,
+    config: &AppRuntimeConfig,
+) -> Result<(), anyhow::Error> {
+    let config = config.clone();
+    let search_url = build_job_search_url(&config);
+    let mut processed_job_ids: HashSet<String> = job_detail_dao::list()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|j| j.id)
+        .collect();
+    logger::info(format!(
+        "猎聘本地已存储 {} 条岗位记录",
+        processed_job_ids.len()
+    ))?;
+
+    let mut seen_job_ids: HashSet<String> = HashSet::new();
+
+    logger::info(format!("正在打开猎聘职位搜索页: {}", search_url))?;
+    page.get(&search_url)?;
+    sleep_random_ms(1200, 2000);
+    apply_liepin_filters(page, &config)?;
+    sleep_random_ms(1200, 1800);
+
+    loop {
+        if is_job_task_stop_requested() {
+            logger::info("猎聘求职任务已结束")?;
+            return Ok(());
+        }
+
+        let jobs = collect_jobs(page)?;
+        if jobs.is_empty() {
+            logger::info("猎聘暂无可处理岗位")?;
+            return Ok(());
+        }
+
+        logger::info(format!("猎聘当前加载到{}条岗位", jobs.len()))?;
+        let mut stats = RoundStats::default();
+        for job in jobs {
+            if is_job_task_stop_requested() {
+                logger::info("猎聘求职任务已结束")?;
+                return Ok(());
+            }
+
+            stats.scanned += 1;
+            let db_id = format!("liepin:{}", job.platform_job_id);
+            if processed_job_ids.contains(&db_id)
+                || processed_job_ids.contains(&job.platform_job_id)
+                || seen_job_ids.contains(&job.platform_job_id)
+            {
+                // 逐条打会把日志刷满，这里只计数，本页结束时汇总
+                stats.skipped_processed += 1;
+                continue;
+            }
+            seen_job_ids.insert(job.platform_job_id.clone());
+
+            let filter_decision = verify::filter_decision(&job, &config);
+            if !filter_decision.matched {
+                stats.skipped_rule += 1;
+                continue;
+            }
+
+            logger::info(format!(
+                "猎聘处理岗位：{} - {}",
+                job.title, job.company_name
+            ))?;
+            if config.job_filter_config.enable_semantic_filter {
+                match crate::llm::evaluate_job_match(&config, &job).await {
+                    Ok(decision) if decision.matched => logger::info(format!(
+                        "猎聘 AI 岗位复核通过（{}分）：{}",
+                        decision.score, decision.reason
+                    ))?,
+                    Ok(decision) => {
+                        stats.skipped_ai += 1;
+                        logger::info(format!(
+                            "猎聘 AI 岗位复核未通过，跳过（{}分）：{}",
+                            decision.score, decision.reason
+                        ))?;
+                        continue;
+                    }
+                    Err(error) => {
+                        stats.skipped_ai += 1;
+                        logger::warning(format!(
+                            "猎聘 AI 岗位复核失败，为避免误投已跳过：{}",
+                            error
+                        ))?;
+                        continue;
+                    }
+                }
+            }
+
+            match greet_job(connection, job.clone(), config.clone()).await {
+                Ok(()) => {
+                    stats.greeted += 1;
+                    processed_job_ids.insert(format!("liepin:{}", job.platform_job_id));
+                    processed_job_ids.insert(job.platform_job_id.clone());
+                }
+                Err(error) => {
+                    stats.greet_failed += 1;
+                    logger::warning(greet_failure_message(&job.title, &job.company_name, &error))?;
+                    continue;
+                }
+            }
+            sleep_random_ms(2500, 4500);
+        }
+
+        logger::info(stats.summary())?;
+
+        if !scroll_next(page)? {
+            logger::info("猎聘岗位列表已触底")?;
+            return Ok(());
+        }
+    }
 }
 
 /// 本页岗位处理统计。跳过类逐条打日志会把有效信息淹掉，改为汇总一条。
@@ -310,10 +315,7 @@ fn push_vec_param(params: &mut Vec<String>, key: &str, values: &[String]) {
     }
 }
 
-fn apply_liepin_filters(
-    page: &ChromiumPage,
-    config: &AppRuntimeConfig,
-) -> Result<(), anyhow::Error> {
+fn apply_liepin_filters(page: &Page, config: &AppRuntimeConfig) -> Result<(), anyhow::Error> {
     let value = page.run_js_await(&build_apply_liepin_filter_script(config))?;
     let result = value.get("value").cloned().unwrap_or(value);
 
@@ -427,7 +429,7 @@ fn job_card_selectors() -> &'static [&'static str] {
     ]
 }
 
-fn collect_jobs(page: &ChromiumPage) -> Result<Vec<RpaJob>, anyhow::Error> {
+fn collect_jobs(page: &Page) -> Result<Vec<RpaJob>, anyhow::Error> {
     let value = page.run_js_await(&build_collect_jobs_script())?;
     let raw = value.get("value").cloned().unwrap_or(value);
     let candidates = serde_json::from_value::<Vec<LiepinJobCandidate>>(raw)?;
@@ -545,7 +547,7 @@ async fn greet_job(
         return Ok(());
     }
 
-    let page = browser_page.new_tab(None)?;
+    let page = browser::new_stealth_tab(browser_page)?;
     let result = async {
         page.get(&job.detail_url)?;
         sleep_random_ms(1200, 2000);
@@ -926,7 +928,6 @@ fn build_wait_image_delivery_script(since: f64) -> String {
     )
 }
 
-
 /// 聊天窗可能还在加载，这些超时只是异常上限，元素一就绪就立刻继续
 const INPUT_READY_TIMEOUT_MS: u32 = 15000;
 const SEND_BUTTON_READY_TIMEOUT_MS: u32 = 15000;
@@ -1102,7 +1103,7 @@ fn save_job_detail(job: &RpaJob) {
     }
 }
 
-fn scroll_next(page: &ChromiumPage) -> Result<bool, anyhow::Error> {
+fn scroll_next(page: &Page) -> Result<bool, anyhow::Error> {
     let before =
         page.run_js_await("document.documentElement.scrollTop || document.body.scrollTop")?;
     page.run_js_await(

--- a/src-tauri/src/rpa/liepin/handler/position_say_hello.rs
+++ b/src-tauri/src/rpa/liepin/handler/position_say_hello.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
-use std::time::Duration;
+use std::path::Path;
+use std::time::{Duration, Instant};
 
 use crate::{
     browser,
@@ -7,7 +8,9 @@ use crate::{
     dao::{job_detail_dao, model::JobDetail},
     logger,
     rpa::{
-        common::RpaJob, greet::build_greet_resources, liepin::LIEPIN_SITE_URL,
+        common::{upload_image_to_file_input, RpaJob},
+        greet::build_greet_resources,
+        liepin::LIEPIN_SITE_URL,
         run_flow::is_job_task_stop_requested,
     },
     utils::salary::decode_salary,
@@ -55,35 +58,35 @@ pub async fn position_say_hello(config: &AppRuntimeConfig) -> Result<(), anyhow:
                 }
 
                 logger::info(format!("猎聘当前加载到{}条岗位", jobs.len()))?;
+                let mut stats = RoundStats::default();
                 for job in jobs {
                     if is_job_task_stop_requested() {
                         logger::info("猎聘求职任务已结束")?;
                         return Ok(());
                     }
 
+                    stats.scanned += 1;
                     let db_id = format!("liepin:{}", job.platform_job_id);
                     if processed_job_ids.contains(&db_id)
                         || processed_job_ids.contains(&job.platform_job_id)
                         || seen_job_ids.contains(&job.platform_job_id)
                     {
-                        logger::info(format!(
-                            "猎聘岗位已沟通过，跳过：{} - {}",
-                            job.title, job.company_name
-                        ))?;
+                        // 逐条打会把日志刷满，这里只计数，本页结束时汇总
+                        stats.skipped_processed += 1;
                         continue;
                     }
                     seen_job_ids.insert(job.platform_job_id.clone());
 
-                    logger::info(format!(
-                        "猎聘当前处理岗位:{} 公司:{}",
-                        job.title, job.company_name
-                    ))?;
-
                     let filter_decision = verify::filter_decision(&job, &config);
                     if !filter_decision.matched {
-                        logger::info(format!("猎聘岗位不匹配，跳过：{}", filter_decision.reason))?;
+                        stats.skipped_rule += 1;
                         continue;
                     }
+
+                    logger::info(format!(
+                        "猎聘处理岗位：{} - {}",
+                        job.title, job.company_name
+                    ))?;
                     if config.job_filter_config.enable_semantic_filter {
                         match crate::llm::evaluate_job_match(&config, &job).await {
                             Ok(decision) if decision.matched => logger::info(format!(
@@ -91,6 +94,7 @@ pub async fn position_say_hello(config: &AppRuntimeConfig) -> Result<(), anyhow:
                                 decision.score, decision.reason
                             ))?,
                             Ok(decision) => {
+                                stats.skipped_ai += 1;
                                 logger::info(format!(
                                     "猎聘 AI 岗位复核未通过，跳过（{}分）：{}",
                                     decision.score, decision.reason
@@ -98,6 +102,7 @@ pub async fn position_say_hello(config: &AppRuntimeConfig) -> Result<(), anyhow:
                                 continue;
                             }
                             Err(error) => {
+                                stats.skipped_ai += 1;
                                 logger::warning(format!(
                                     "猎聘 AI 岗位复核失败，为避免误投已跳过：{}",
                                     error
@@ -109,10 +114,12 @@ pub async fn position_say_hello(config: &AppRuntimeConfig) -> Result<(), anyhow:
 
                     match greet_job(page, job.clone(), config.clone()).await {
                         Ok(()) => {
+                            stats.greeted += 1;
                             processed_job_ids.insert(format!("liepin:{}", job.platform_job_id));
                             processed_job_ids.insert(job.platform_job_id.clone());
                         }
                         Err(error) => {
+                            stats.greet_failed += 1;
                             logger::warning(greet_failure_message(
                                 &job.title,
                                 &job.company_name,
@@ -124,6 +131,8 @@ pub async fn position_say_hello(config: &AppRuntimeConfig) -> Result<(), anyhow:
                     sleep_random_ms(2500, 4500);
                 }
 
+                logger::info(stats.summary())?;
+
                 if !scroll_next(page)? {
                     logger::info("猎聘岗位列表已触底")?;
                     return Ok(());
@@ -132,6 +141,34 @@ pub async fn position_say_hello(config: &AppRuntimeConfig) -> Result<(), anyhow:
         })
     })
     .await
+}
+
+/// 本页岗位处理统计。跳过类逐条打日志会把有效信息淹掉，改为汇总一条。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RoundStats {
+    scanned: u32,
+    /// 本地库已有记录，之前沟通过
+    skipped_processed: u32,
+    /// 确定性规则未通过
+    skipped_rule: u32,
+    /// AI 语义复核未通过或失败
+    skipped_ai: u32,
+    greeted: u32,
+    greet_failed: u32,
+}
+
+impl RoundStats {
+    fn summary(&self) -> String {
+        format!(
+            "猎聘本页 {} 条岗位：打招呼成功 {} 条，失败 {} 条；已沟通跳过 {} 条，规则过滤跳过 {} 条，AI 复核跳过 {} 条",
+            self.scanned,
+            self.greeted,
+            self.greet_failed,
+            self.skipped_processed,
+            self.skipped_rule,
+            self.skipped_ai
+        )
+    }
 }
 
 fn build_job_search_url(config: &AppRuntimeConfig) -> String {
@@ -278,8 +315,26 @@ fn apply_liepin_filters(
     config: &AppRuntimeConfig,
 ) -> Result<(), anyhow::Error> {
     let value = page.run_js_await(&build_apply_liepin_filter_script(config))?;
-    let summary = value.get("value").cloned().unwrap_or(value).to_string();
-    logger::info(format!("猎聘筛选应用结果: {}", summary))?;
+    let result = value.get("value").cloned().unwrap_or(value);
+
+    // 顺利应用时不必汇报，只有页面上没找到对应筛选项才值得提醒
+    let missing = result
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter(|item| item.get("status").and_then(|v| v.as_str()) == Some("missing"))
+                .filter_map(|item| item.get("key").and_then(|v| v.as_str()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if !missing.is_empty() {
+        logger::warning(format!(
+            "猎聘页面上未找到筛选项 {}，该条件改由搜索链接参数生效",
+            missing.join("、")
+        ))?;
+    }
+
     Ok(())
 }
 
@@ -557,14 +612,321 @@ pub(crate) fn send_resources(
             ReplayResourceType::Text | ReplayResourceType::LLM => {
                 send_text_resource(page, &resource.content)?;
             }
+            // 图片属于附加内容，失败只告警不中断，避免因一张图让整个岗位打招呼判失败
             ReplayResourceType::Image => {
-                logger::warning("猎聘暂不支持自动发送图片资源，已跳过")?;
+                if let Err(error) = send_image_resource(page, &resource.content) {
+                    logger::warning(format!("猎聘图片发送失败，已跳过该条：{}", error))?;
+                }
             }
         }
     }
 
     Ok(())
 }
+
+/// 猎聘聊天窗的上传控件是 rc-upload（`ant-im-upload`），
+/// input 写的是 `accept="jpg, jpeg, png, bmp"`，不含 image 字样，
+/// 因此不能沿用 Boss 的 `accept*="image"` 选择器。
+const LIEPIN_IMAGE_INPUT_SELECTORS: &[&str] = &[
+    ".im-ui-upload-container input[type='file']",
+    ".ant-im-upload input[type='file']",
+    "input[type='file'][accept*='jpg']",
+    "input[type='file'][accept*='png']",
+    "input[type='file'][accept*='image']",
+];
+
+/// 与猎聘上传控件 accept 保持一致，其余格式它不接收
+const LIEPIN_SUPPORTED_IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "bmp"];
+
+fn ensure_supported_image(image_path: &Path) -> Result<(), anyhow::Error> {
+    let extension = image_path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if !LIEPIN_SUPPORTED_IMAGE_EXTENSIONS.contains(&extension.as_str()) {
+        return Err(anyhow::anyhow!(
+            "猎聘仅支持 jpg/jpeg/png/bmp 图片，当前文件格式为 {}",
+            if extension.is_empty() {
+                "(无扩展名)"
+            } else {
+                extension.as_str()
+            }
+        ));
+    }
+
+    if !image_path.is_file() {
+        return Err(anyhow::anyhow!("图片文件不存在: {}", image_path.display()));
+    }
+
+    Ok(())
+}
+
+fn send_image_resource(page: &Page, image_path: &str) -> Result<(), anyhow::Error> {
+    let path = Path::new(image_path.trim());
+    ensure_supported_image(path)?;
+
+    // 上传成不成功由真实的网络响应说了算。先在页面里挂上请求记录器，
+    // 再触发上传，最后读记录——不再靠“等几秒看看 DOM 变没变”这种猜测。
+    let since = install_request_recorder(page)?;
+    let outcome = upload_image_to_file_input(page, path, LIEPIN_IMAGE_INPUT_SELECTORS)?;
+    if !outcome.success {
+        return Err(anyhow::anyhow!("找不到图片上传入口（{}）", outcome.message));
+    }
+
+    // 成功路径只说结果；诊断细节留给失败分支，避免刷屏
+    let delivery = wait_for_image_delivery(page, since)?;
+    if !delivery.uploaded {
+        return Err(anyhow::anyhow!(
+            "{} 秒内没有观察到图片上传请求{}",
+            delivery.waited_ms / 1000,
+            format_seen_requests(&delivery.seen)
+        ));
+    }
+    if !delivery.sent {
+        // 文件传上去了但没发成消息，这是实测出现过的情况，必须报出来
+        return Err(anyhow::anyhow!(
+            "图片已上传但未发出消息{}{}",
+            if delivery.clicked {
+                "（已补点发送按钮仍未发出）"
+            } else {
+                ""
+            },
+            format_seen_requests(&delivery.seen)
+        ));
+    }
+
+    logger::info("猎聘图片已发送")?;
+
+    Ok(())
+}
+
+fn format_seen_requests(seen: &[String]) -> String {
+    if seen.is_empty() {
+        return "，期间页面没有发出任何 POST 请求".to_string();
+    }
+    format!("，期间的 POST 请求：{}", seen.join("；"))
+}
+
+/// 在页面里挂 fetch / XMLHttpRequest 记录器，返回本次的时间基准。
+///
+/// 重复注入是安全的（第二次直接复用），标签页关闭后自然消失，
+/// 不像 CDP 监听那样会留下后台线程和连接。
+fn install_request_recorder(page: &Page) -> Result<f64, anyhow::Error> {
+    let value = page.run_js_await(INSTALL_REQUEST_RECORDER_SCRIPT)?;
+    let result = value.get("value").cloned().unwrap_or(value);
+    Ok(result
+        .get("now")
+        .and_then(|value| value.as_f64())
+        .unwrap_or_default())
+}
+
+const INSTALL_REQUEST_RECORDER_SCRIPT: &str = r#"
+    (() => {
+        if (!window.__fjRequestRecords) {
+            window.__fjRequestRecords = [];
+        }
+        const push = (url, status, body) => {
+            window.__fjRequestRecords.push({
+                url: String(url || ""),
+                status: Number(status) || 0,
+                body: String(body || "").slice(0, 4000),
+                at: performance.now()
+            });
+            // 只留最近的记录，避免长会话里无限增长
+            if (window.__fjRequestRecords.length > 60) {
+                window.__fjRequestRecords.splice(0, window.__fjRequestRecords.length - 60);
+            }
+        };
+
+        if (!window.__fjRecorderInstalled) {
+            const originalFetch = window.fetch;
+            if (typeof originalFetch === "function") {
+                window.fetch = function (...args) {
+                    const request = args[0];
+                    const url = typeof request === "string" ? request : (request && request.url) || "";
+                    const method = String(
+                        (args[1] && args[1].method) || (request && request.method) || "GET"
+                    ).toUpperCase();
+                    return originalFetch.apply(this, args).then((response) => {
+                        if (method === "POST") {
+                            response.clone().text()
+                                .then((text) => push(url, response.status, text))
+                                .catch(() => push(url, response.status, ""));
+                        }
+                        return response;
+                    });
+                };
+            }
+
+            const originalOpen = XMLHttpRequest.prototype.open;
+            const originalSend = XMLHttpRequest.prototype.send;
+            XMLHttpRequest.prototype.open = function (method, url, ...rest) {
+                this.__fjMethod = String(method || "").toUpperCase();
+                this.__fjUrl = url;
+                return originalOpen.call(this, method, url, ...rest);
+            };
+            XMLHttpRequest.prototype.send = function (...args) {
+                this.addEventListener("loadend", () => {
+                    if (this.__fjMethod === "POST") {
+                        let text = "";
+                        try {
+                            text = this.responseType === "" || this.responseType === "text"
+                                ? this.responseText
+                                : JSON.stringify(this.response);
+                        } catch (error) {
+                            text = "";
+                        }
+                        push(this.__fjUrl, this.status, text);
+                    }
+                });
+                return originalSend.apply(this, args);
+            };
+
+            window.__fjRecorderInstalled = true;
+        }
+
+        return { now: performance.now() };
+    })()
+"#;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ImageDelivery {
+    /// 文件已传到 file.liepin.com
+    uploaded: bool,
+    /// 已经通过 IM 接口发成消息。只上传不发送是实测出现过的失败形态
+    sent: bool,
+    /// 是否补点过发送按钮
+    clicked: bool,
+    waited_ms: i64,
+    /// 判定失败时把期间的 POST 请求带回来，接口改版时能直接看出新地址
+    seen: Vec<String>,
+}
+
+/// 轮询请求记录，直到图片既传上去、又发成了消息。
+///
+/// 实测猎聘分两步：`file.liepin.com/upload/public-file.json` 传文件，
+/// `api-c.liepin.com/api/com.liepin.im.c.chat.send-push` 发消息。
+/// 只有上传成功而消息没发出的情况真实出现过，所以两步都要确认。
+fn wait_for_image_delivery(page: &Page, since: f64) -> Result<ImageDelivery, anyhow::Error> {
+    let value = page.run_js_await(&build_wait_image_delivery_script(since))?;
+    let result = value.get("value").cloned().unwrap_or(value);
+    let flag = |key: &str| {
+        result
+            .get(key)
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
+    };
+
+    Ok(ImageDelivery {
+        uploaded: flag("uploaded"),
+        sent: flag("sent"),
+        clicked: flag("clicked"),
+        waited_ms: result
+            .get("waitedMs")
+            .and_then(|value| value.as_i64())
+            .unwrap_or_default(),
+        seen: result
+            .get("seen")
+            .and_then(|value| value.as_array())
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+    })
+}
+
+fn build_wait_image_delivery_script(since: f64) -> String {
+    format!(
+        r#"
+        (async () => {{
+            const since = {since};
+            const stepMs = 200;
+            // 仅作异常上限：两步都确认到就立刻返回，不会等满
+            const maxAttempts = 90;
+            // 上传完成后消息迟迟没发出，就补点一次发送按钮
+            const clickFallbackAfterMs = 2500;
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const recent = () => (window.__fjRequestRecords || []).filter((item) => item.at > since);
+            const ok = (item) => item.status >= 200 && item.status < 300;
+            // 按接口地址判定，而不是猜返回体结构
+            const isUpload = (item) => ok(item) && /\/upload\/|file\.liepin\.com/i.test(item.url);
+            const isSend = (item) => ok(item) && /chat\.send-push|chat\.send|send-push/i.test(item.url);
+
+            const visible = (el) => {{
+                if (!el) return false;
+                const rect = el.getBoundingClientRect();
+                const style = window.getComputedStyle(el);
+                return rect.width > 0 && rect.height > 0
+                    && style.visibility !== "hidden"
+                    && style.display !== "none";
+            }};
+            const isDisabled = (el) => {{
+                const className = el.getAttribute("class") || "";
+                return Boolean(el.disabled)
+                    || el.getAttribute("aria-disabled") === "true"
+                    || className.includes("disabled")
+                    || className.includes("ant-im-btn-disabled");
+            }};
+            const clickSendIfEnabled = () => {{
+                const antImButtons = Array.from(document.querySelectorAll(".ant-im-btn")).filter(visible);
+                const button = antImButtons[1] || Array
+                    .from(document.querySelectorAll("button.im-ui-basic-send-btn, button.ant-im-btn-primary, .btn-send, .send-btn"))
+                    .filter(visible)
+                    .find((el) => {{
+                        const text = (el.innerText || el.textContent || "").trim();
+                        const className = el.getAttribute("class") || "";
+                        return text.includes("发送") || /send/i.test(className);
+                    }});
+                if (!button || isDisabled(button)) return false;
+                button.click();
+                return true;
+            }};
+
+            let uploaded = false;
+            let uploadedAtMs = -1;
+            let clicked = false;
+
+            for (let attempt = 0; attempt < maxAttempts; attempt += 1) {{
+                const waitedMs = attempt * stepMs;
+                const records = recent();
+
+                if (!uploaded && records.some(isUpload)) {{
+                    uploaded = true;
+                    uploadedAtMs = waitedMs;
+                }}
+                if (uploaded && records.some(isSend)) {{
+                    return {{ uploaded: true, sent: true, clicked, waitedMs }};
+                }}
+                // 传完了却没发出去：按钮一旦可用就补点一次救回来。
+                // 不可用只说明此刻还不能点，下一轮继续看，点成功一次即止。
+                if (uploaded && !clicked && waitedMs - uploadedAtMs >= clickFallbackAfterMs) {{
+                    clicked = clickSendIfEnabled();
+                }}
+
+                await sleep(stepMs);
+            }}
+
+            return {{
+                uploaded,
+                sent: false,
+                clicked,
+                waitedMs: maxAttempts * stepMs,
+                seen: recent().map((item) => item.url + " -> " + item.status)
+            }};
+        }})()
+        "#
+    )
+}
+
+
+/// 聊天窗可能还在加载，这些超时只是异常上限，元素一就绪就立刻继续
+const INPUT_READY_TIMEOUT_MS: u32 = 15000;
+const SEND_BUTTON_READY_TIMEOUT_MS: u32 = 15000;
+const INPUT_CLEARED_TIMEOUT_MS: u32 = 8000;
 
 fn send_text_resource(page: &Page, text: &str) -> Result<(), anyhow::Error> {
     let value = page.run_js_await(&build_send_text_script(text))?;
@@ -573,37 +935,17 @@ fn send_text_resource(page: &Page, text: &str) -> Result<(), anyhow::Error> {
         .get("success")
         .and_then(|value| value.as_bool())
         .unwrap_or(false);
+    let message = result
+        .get("message")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
 
     if !success {
-        return Err(anyhow::anyhow!(
-            "猎聘消息发送失败: {}",
-            result
-                .get("message")
-                .and_then(|value| value.as_str())
-                .unwrap_or("未找到可用发送按钮")
-        ));
+        return Err(anyhow::anyhow!("消息发送失败：{}", message));
     }
 
-    sleep_random_ms(700, 1000);
-
-    let check = page.run_js_await(&build_check_message_sent_script(text))?;
-    let check_result = check.get("value").cloned().unwrap_or(check);
-    let sent = check_result
-        .get("success")
-        .and_then(|value| value.as_bool())
-        .unwrap_or(false);
-    if sent {
-        logger::info(format!("猎聘消息发送点击结果: {}", check_result))?;
-        return Ok(());
-    }
-
-    Err(anyhow::anyhow!(
-        "猎聘消息发送失败: {}",
-        check_result
-            .get("message")
-            .and_then(|value| value.as_str())
-            .unwrap_or("已点击发送按钮，但输入框内容未清空")
-    ))
+    // 成功不单独记，末尾的“初次沟通成功”已经覆盖
+    Ok(())
 }
 
 fn build_send_text_script(text: &str) -> String {
@@ -647,13 +989,52 @@ fn build_send_text_script(text: &str) -> String {
                     || className.includes("ant-im-btn-disabled");
             }};
 
-            const input = Array
+            // 等状态而不是等时间：条件成立立刻继续，页面慢就自动多等，
+            // 超时只是异常上限，不参与正常判定
+            const waitFor = async (getter, timeoutMs, label) => {{
+                const deadline = performance.now() + timeoutMs;
+                for (;;) {{
+                    const found = getter();
+                    if (found) return found;
+                    if (performance.now() >= deadline) {{
+                        return null;
+                    }}
+                    await sleep(150);
+                }}
+            }};
+            const findInput = () => Array
                 .from(document.querySelectorAll("textarea, input[type='text'], div[contenteditable='true'], [contenteditable='true']"))
                 .filter(visible)
                 .find((el) => !el.disabled && !el.readOnly);
+            const findSendButton = () => {{
+                const antImButtons = Array.from(document.querySelectorAll(".ant-im-btn"));
+                const preferred = antImButtons[1];
+                if (preferred && visible(preferred) && !isDisabled(preferred)) {{
+                    return preferred;
+                }}
+                return Array
+                    .from(document.querySelectorAll("button.im-ui-basic-send-btn, button.ant-im-btn-primary, button, a, div[role='button'], span[role='button'], .btn-send, .send-btn, [class*='send'], [class*='Send']"))
+                    .filter(visible)
+                    .find((el) => {{
+                        const text = (el.innerText || el.textContent || "").trim();
+                        const className = el.getAttribute("class") || "";
+                        return (text === "发送"
+                                || text.includes("发送")
+                                || className.includes("im-ui-basic-send-btn")
+                                || className.includes("ant-im-btn-primary")
+                                || /(^|\s)(btn-send|send-btn)(\s|$)/.test(className)
+                                || /send|Send/.test(className))
+                            && !isDisabled(el);
+                    }});
+            }};
 
+            // 聊天窗可能还在加载，等它出现而不是查一次就判死
+            const input = await waitFor(findInput, {INPUT_READY_TIMEOUT_MS});
             if (!input) {{
-                return {{ success: false, message: "未找到聊天输入框" }};
+                return {{
+                    success: false,
+                    message: "聊天输入框在 {INPUT_READY_TIMEOUT_MS} 毫秒内未出现"
+                }};
             }}
 
             input.focus();
@@ -663,72 +1044,33 @@ fn build_send_text_script(text: &str) -> String {
                 setNativeValue(input, message);
             }}
             dispatch(input);
-            await sleep(500);
 
-            const antImButtons = Array.from(document.querySelectorAll(".ant-im-btn"));
-            const preferredButton = antImButtons[1];
-            const button = preferredButton && visible(preferredButton) && !isDisabled(preferredButton)
-                ? preferredButton
-                : Array
-                .from(document.querySelectorAll("button.im-ui-basic-send-btn, button.ant-im-btn-primary, button, a, div[role='button'], span[role='button'], .btn-send, .send-btn, [class*='send'], [class*='Send']"))
-                .filter(visible)
-                .find((el) => {{
-                    const text = (el.innerText || el.textContent || "").trim();
-                    const className = el.getAttribute("class") || "";
-                    return (text === "发送"
-                            || text.includes("发送")
-                            || className.includes("im-ui-basic-send-btn")
-                            || className.includes("ant-im-btn-primary")
-                            || /(^|\s)(btn-send|send-btn)(\s|$)/.test(className)
-                            || /send|Send/.test(className))
-                        && !isDisabled(el);
-                }});
-
+            // 填入内容后按钮才会由 disabled 变可用，同样等状态
+            const button = await waitFor(findSendButton, {SEND_BUTTON_READY_TIMEOUT_MS});
             if (!button) {{
                 return {{
                     success: false,
-                    message: "未找到可用发送按钮",
+                    message: "发送按钮在 {SEND_BUTTON_READY_TIMEOUT_MS} 毫秒内未变为可用",
                     inputText: inputValue(input)
                 }};
             }}
 
             button.scrollIntoView({{ block: "center", inline: "center" }});
-            await sleep(200);
             button.click();
-            await sleep(300);
+
+            // 发出去的标志是输入框被清空，等这个状态，别按固定时长猜
+            const cleared = await waitFor(
+                () => !inputValue(input).includes(message) || null,
+                {INPUT_CLEARED_TIMEOUT_MS}
+            );
+
             return {{
-                success: true,
+                success: Boolean(cleared),
+                message: cleared ? "输入框已清空" : "已点击发送按钮，但输入框内容未清空",
                 inputText: inputValue(input),
                 buttonText: (button.innerText || button.textContent || "").trim(),
                 buttonClass: button.getAttribute("class") || ""
             }};
-        }})()
-        "#
-    )
-}
-
-fn build_check_message_sent_script(text: &str) -> String {
-    let text_json = serde_json::to_string(text).unwrap_or_else(|_| "\"\"".to_string());
-    format!(
-        r#"
-        (() => {{
-            const message = {text_json};
-            const visible = (el) => {{
-                if (!el) return false;
-                const rect = el.getBoundingClientRect();
-                const style = window.getComputedStyle(el);
-                return rect.width > 0 && rect.height > 0
-                    && style.visibility !== "hidden"
-                    && style.display !== "none";
-            }};
-            const inputValue = (el) => (el.isContentEditable ? el.textContent : el.value) || "";
-            const inputs = Array
-                .from(document.querySelectorAll("textarea, input[type='text'], div[contenteditable='true'], [contenteditable='true']"))
-                .filter(visible);
-            const stillPending = inputs.some((input) => inputValue(input).includes(message));
-            return stillPending
-                ? {{ success: false, message: "已点击发送按钮，但输入框内容未清空" }}
-                : {{ success: true, message: "输入框已清空" }};
         }})()
         "#
     )
@@ -785,17 +1127,31 @@ pub(crate) fn text_from_first(page: &Page, selectors: &[&str]) -> Result<String,
     Ok(String::new())
 }
 
+/// 可点击元素的等待上限。慢网络下聊天入口渲染得晚，
+/// 扫一遍就判死会让整个岗位白跑（含已花掉的 AI 复核）。
+const CLICKABLE_READY_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// 等待任一选择器出现并点击：命中立刻返回，没出现就继续等到上限。
 pub(crate) fn click_first(page: &Page, selectors: &[&str]) -> Result<(), anyhow::Error> {
-    for selector in selectors {
-        if let Some(ele) = page.ele(selector)? {
-            ele.click()?;
-            return Ok(());
+    let deadline = Instant::now() + CLICKABLE_READY_TIMEOUT;
+    loop {
+        for selector in selectors {
+            // 页面正在导航时 ele 会短暂报错，这属于“还没就绪”而不是失败
+            if let Ok(Some(ele)) = page.ele(selector) {
+                ele.click()?;
+                return Ok(());
+            }
         }
+
+        if Instant::now() >= deadline {
+            return Err(anyhow::anyhow!(
+                "{} 秒内未出现可点击元素: {}",
+                CLICKABLE_READY_TIMEOUT.as_secs(),
+                selectors.join(", ")
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(200));
     }
-    Err(anyhow::anyhow!(
-        "未找到可点击元素: {}",
-        selectors.join(", ")
-    ))
 }
 
 fn normalize_url(href: &str) -> String {
@@ -950,19 +1306,29 @@ mod tests {
         assert!(script.contains("text.includes(\"发送\")"));
         assert!(script.contains("button.im-ui-basic-send-btn"));
         assert!(script.contains("button.ant-im-btn-primary"));
-        assert!(script.contains("await sleep(500)"));
         assert!(script.contains("ariaDisabled === \"true\""));
         assert!(script.contains("document.querySelectorAll(\".ant-im-btn\")"));
         assert!(script.contains("antImButtons[1]"));
         assert!(script.contains("button.click()"));
-        assert!(script.contains("success: true"));
     }
 
     #[test]
-    fn check_message_sent_script_fails_when_input_still_contains_message() {
-        let script = build_check_message_sent_script("你好，想进一步沟通");
+    fn send_text_script_waits_for_elements_instead_of_sleeping_a_fixed_time() {
+        // “等 500ms 再查一次，查不到就判失败”会在页面慢时误报“未找到可用发送按钮”
+        let script = build_send_text_script("你好");
 
-        assert!(script.contains("stillPending"));
+        assert!(!script.contains("await sleep(500)"));
+        assert!(script.contains("waitFor(findInput"));
+        assert!(script.contains("waitFor(findSendButton"));
+        assert!(script.contains("聊天输入框在 15000 毫秒内未出现"));
+        assert!(script.contains("发送按钮在 15000 毫秒内未变为可用"));
+    }
+
+    #[test]
+    fn send_text_script_confirms_delivery_by_waiting_for_the_input_to_clear() {
+        let script = build_send_text_script("你好");
+
+        assert!(script.contains("inputValue(input).includes(message)"));
         assert!(script.contains("已点击发送按钮，但输入框内容未清空"));
         assert!(script.contains("输入框已清空"));
     }
@@ -1006,6 +1372,109 @@ mod tests {
         assert_eq!(job.salary, "15-30k·13薪");
         assert_eq!(job.company_name, "皓元医药");
         assert_eq!(job.platform_job_id, "1979771045.shtml");
+    }
+
+    #[test]
+    fn image_input_selectors_match_liepin_ant_im_upload_instead_of_accept_image() {
+        // 猎聘 input 写的是 accept="jpg, jpeg, png, bmp"，Boss 那套 accept*="image" 命中不到
+        assert_eq!(
+            LIEPIN_IMAGE_INPUT_SELECTORS[0],
+            ".im-ui-upload-container input[type='file']"
+        );
+        assert!(LIEPIN_IMAGE_INPUT_SELECTORS
+            .iter()
+            .any(|selector| selector.contains("ant-im-upload")));
+        assert!(LIEPIN_IMAGE_INPUT_SELECTORS
+            .iter()
+            .any(|selector| selector.contains("accept*='jpg'")));
+    }
+
+    #[test]
+    fn rejects_image_formats_liepin_upload_does_not_accept() {
+        let error = ensure_supported_image(Path::new("C:/tmp/demo.gif")).unwrap_err();
+
+        assert!(error.to_string().contains("jpg/jpeg/png/bmp"));
+        assert!(error.to_string().contains("gif"));
+    }
+
+    #[test]
+    fn reports_missing_file_for_supported_extension() {
+        let error =
+            ensure_supported_image(Path::new("./__not_exists__/liepin-greet.png")).unwrap_err();
+
+        assert!(error.to_string().contains("图片文件不存在"));
+    }
+
+    #[test]
+    fn delivery_is_confirmed_by_the_real_liepin_endpoints() {
+        let script = build_wait_image_delivery_script(1234.5);
+
+        assert!(script.contains("const since = 1234.5"));
+        assert!(script.contains("item.status >= 200 && item.status < 300"));
+        // 实测接口：file.liepin.com 传文件，chat.send-push 发消息
+        assert!(script.contains(r"/\/upload\/|file\.liepin\.com/i"));
+        assert!(script.contains(r"/chat\.send-push|chat\.send|send-push/i"));
+    }
+
+    #[test]
+    fn uploaded_but_unsent_image_is_a_failure_not_a_success() {
+        // 实测出现过：文件传上去了，但没有 send-push，图片其实没发出去
+        let script = build_wait_image_delivery_script(0.0);
+
+        assert!(script.contains("uploaded: true, sent: true"));
+        assert!(script.contains("sent: false"));
+        assert!(script.contains("clicked = clickSendIfEnabled()"));
+    }
+
+    #[test]
+    fn missing_delivery_reports_the_post_requests_it_saw() {
+        // 接口改版时把期间的 POST 请求带回日志，能直接看出新地址
+        let script = build_wait_image_delivery_script(0.0);
+
+        assert!(script.contains("seen: recent().map((item) => item.url + \" -> \" + item.status)"));
+        assert!(format_seen_requests(&[]).contains("没有发出任何 POST 请求"));
+        assert!(format_seen_requests(&[
+            "https://file.liepin.com/upload/public-file.json -> 200".to_string()
+        ])
+        .contains("public-file.json"));
+    }
+
+    #[test]
+    fn request_recorder_hooks_both_fetch_and_xhr_and_is_idempotent() {
+        assert!(INSTALL_REQUEST_RECORDER_SCRIPT.contains("window.fetch = function"));
+        assert!(INSTALL_REQUEST_RECORDER_SCRIPT.contains("XMLHttpRequest.prototype.send"));
+        // 同一标签页发多张图会重复注入，必须幂等
+        assert!(INSTALL_REQUEST_RECORDER_SCRIPT.contains("if (!window.__fjRecorderInstalled)"));
+        assert!(INSTALL_REQUEST_RECORDER_SCRIPT.contains("return { now: performance.now() }"));
+    }
+
+    #[test]
+    fn send_button_fallback_only_clicks_when_enabled() {
+        let script = build_wait_image_delivery_script(0.0);
+
+        assert!(script.contains("ant-im-btn-disabled"));
+        assert!(script.contains("if (!button || isDisabled(button)) return false;"));
+    }
+
+    #[test]
+    fn round_summary_replaces_per_job_skip_logs_with_one_line() {
+        let stats = RoundStats {
+            scanned: 42,
+            skipped_processed: 28,
+            skipped_rule: 8,
+            skipped_ai: 3,
+            greeted: 2,
+            greet_failed: 1,
+        };
+
+        let summary = stats.summary();
+
+        assert!(summary.contains("42 条岗位"));
+        assert!(summary.contains("成功 2 条"));
+        assert!(summary.contains("失败 1 条"));
+        assert!(summary.contains("已沟通跳过 28 条"));
+        assert!(summary.contains("规则过滤跳过 8 条"));
+        assert!(summary.contains("AI 复核跳过 3 条"));
     }
 
     #[test]

--- a/src-tauri/src/rpa/liepin/handler/position_say_hello.rs
+++ b/src-tauri/src/rpa/liepin/handler/position_say_hello.rs
@@ -712,7 +712,7 @@ fn format_seen_requests(seen: &[String]) -> String {
 ///
 /// 重复注入是安全的（第二次直接复用），标签页关闭后自然消失，
 /// 不像 CDP 监听那样会留下后台线程和连接。
-fn install_request_recorder(page: &Page) -> Result<f64, anyhow::Error> {
+pub(crate) fn install_request_recorder(page: &Page) -> Result<f64, anyhow::Error> {
     let value = page.run_js_await(INSTALL_REQUEST_RECORDER_SCRIPT)?;
     let result = value.get("value").cloned().unwrap_or(value);
     Ok(result
@@ -727,10 +727,14 @@ const INSTALL_REQUEST_RECORDER_SCRIPT: &str = r#"
             window.__fjRequestRecords = [];
         }
         const push = (url, status, body) => {
+            const address = String(url || "");
+            // 判断发送成败只要个开头就够；但 IM 的会话列表和聊天记录要整段留下来给解析用，
+            // 截断会直接把 JSON 弄坏
+            const limit = /com\.liepin\.im\./.test(address) ? 400000 : 4000;
             window.__fjRequestRecords.push({
-                url: String(url || ""),
+                url: address,
                 status: Number(status) || 0,
-                body: String(body || "").slice(0, 4000),
+                body: String(body || "").slice(0, limit),
                 at: performance.now()
             });
             // 只留最近的记录，避免长会话里无限增长
@@ -1446,6 +1450,14 @@ mod tests {
         // 同一标签页发多张图会重复注入，必须幂等
         assert!(INSTALL_REQUEST_RECORDER_SCRIPT.contains("if (!window.__fjRecorderInstalled)"));
         assert!(INSTALL_REQUEST_RECORDER_SCRIPT.contains("return { now: performance.now() }"));
+    }
+
+    /// 会话列表实测 30KB、聊天记录 6KB，按 4000 截断会直接把 JSON 弄坏，
+    /// 沟通那边就只能退回刮 DOM
+    #[test]
+    fn im_responses_are_recorded_in_full_while_others_stay_truncated() {
+        assert!(INSTALL_REQUEST_RECORDER_SCRIPT
+            .contains(r#"/com\.liepin\.im\./.test(address) ? 400000 : 4000"#));
     }
 
     #[test]

--- a/src-tauri/src/rpa/liepin/handler/reply_unread.rs
+++ b/src-tauri/src/rpa/liepin/handler/reply_unread.rs
@@ -1,8 +1,9 @@
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use anyhow::Context;
 use regex::Regex;
-use rust_drission::{utils::sleep_random_ms, Element, Page};
+use rust_drission::{utils::sleep_random_ms, Page};
+use serde::Deserialize;
 
 use crate::{
     browser,
@@ -10,22 +11,53 @@ use crate::{
     logger,
     rpa::{
         common::ChatMessage,
-        liepin::{handler::position_say_hello::send_resources, LIEPIN_CHAT_URL},
+        liepin::{
+            handler::position_say_hello::{install_request_recorder, send_resources},
+            LIEPIN_USER_HOME_URL,
+        },
         run_flow::is_job_task_stop_requested,
     },
 };
+
+/// 沟通入口气泡，点开后弹出右侧会话抽屉
+const CHAT_ENTRY: &str = ".im-ui-basic-entry";
+/// 抽屉里的会话卡
+const CONTACT_ITEM: &str = ".im-ui-contact-list-item";
+/// 聊天窗的消息列表容器。会话列表和聊天窗同屏共存，
+/// 从 DOM 取消息必须限定在这个作用域里，否则会把左侧会话摘要一起抓进来
+const MSG_LIST: &str = ".im-ui-msg-list-content";
+
+/// 猎聘 IM 接口。抽屉打开时页面自己会拉会话列表，点开会话时会拉历史消息，
+/// 被动抓响应即可拿到结构化数据 —— 和 Boss 拦 `zpchat/geek/historyMsg` 是同一套路数。
+///
+/// 抓包走的是页面里的 fetch/XHR 记录器（`install_request_recorder`），不是 CDP 监听：
+/// 同一套记录器在图片发送里已经抓到过 `com.liepin.im.c.chat.send-push`，
+/// 而 CDP 那条路在猎聘这个页面上实测收不到包。
+const CONTACT_LIST_API: &str = "com.liepin.im.c.contact.get-contact-list";
+const CHAT_LIST_API: &str = "com.liepin.im.c.chat.chat-list";
+const API_WAIT_MS: u32 = 8000;
+
+/// 列表懒加载的兜底上限。未读消息一定排在列表顶部（按最后消息时间倒序），
+/// 滚动只是为了捞长列表里的漏网之鱼，不需要翻到底
+const MAX_SCROLL_ROUNDS: usize = 10;
+const OPEN_DRAWER_RETRIES: usize = 3;
 
 pub async fn reply_unread(config: &AppRuntimeConfig) -> Result<Vec<ChatMessage>, anyhow::Error> {
     let config = config.clone();
 
     browser::with_new_tab(|page| {
         Box::pin(async move {
-            logger::info("正在打开猎聘沟通页面")?;
-            page.get(LIEPIN_CHAT_URL)?;
-            sleep_random_ms(1200, 2000);
+            logger::info("正在打开猎聘沟通面板")?;
+            page.get(LIEPIN_USER_HOME_URL)?;
 
-            click_unread_filter(page)?;
+            // 会话列表是抽屉打开那一刻才拉的，记录器必须赶在那次点击之前挂上
+            let mut since = open_chat_drawer(page)?;
+
             let replay_config = config.replay_config.clone();
+            // 处理完的会话未读角标会消失，但列表会随新消息重排，
+            // 用会话 id 去重才不会漏处理或重复处理
+            let mut handled: HashSet<String> = HashSet::new();
+            let mut scrolled = 0usize;
 
             loop {
                 if is_job_task_stop_requested() {
@@ -33,32 +65,75 @@ pub async fn reply_unread(config: &AppRuntimeConfig) -> Result<Vec<ChatMessage>,
                     return Ok(Vec::new());
                 }
 
-                let chats = collect_chat_cards(page)?;
-                if chats.is_empty() {
-                    logger::info("猎聘没有未读消息")?;
-                    return Ok(Vec::new());
+                let (contacts, source) = collect_unread_contacts(page, since)?;
+                let pending: Vec<UnreadContact> = contacts
+                    .into_iter()
+                    .filter(|contact| !handled.contains(&contact.imid))
+                    .collect();
+
+                if pending.is_empty() {
+                    if scrolled >= MAX_SCROLL_ROUNDS {
+                        logger::info("猎聘会话列表已翻到上限，停止查找")?;
+                        return Ok(Vec::new());
+                    }
+                    // 滚动会触发下一页会话列表，时间基准要往前推，免得读到上一次的响应
+                    since = install_request_recorder(page)?;
+                    if !scroll_contact_list(page)? {
+                        if handled.is_empty() {
+                            logger::info("猎聘没有未读消息")?;
+                        } else {
+                            logger::info(format!(
+                                "猎聘未读消息已处理完成，共 {} 个会话",
+                                handled.len()
+                            ))?;
+                        }
+                        return Ok(Vec::new());
+                    }
+                    scrolled += 1;
+                    continue;
                 }
 
-                logger::info(format!("猎聘当前未读会话数: {}", chats.len()))?;
-                for (index, chat) in chats.iter().enumerate() {
+                logger::info(format!(
+                    "猎聘当前未读会话数: {}（取自{}）",
+                    pending.len(),
+                    source.label()
+                ))?;
+                let total = pending.len();
+                for (index, contact) in pending.into_iter().enumerate() {
                     if is_job_task_stop_requested() {
                         logger::info("猎聘沟通任务已结束")?;
                         return Ok(Vec::new());
                     }
 
-                    chat.click()?;
-                    sleep_random_ms(800, 1200);
-                    click_resume_action(page)?;
+                    // 先记账再点击：这一轮无论成功失败都不再重试同一个会话，避免死循环
+                    handled.insert(contact.imid.clone());
 
-                    let chat_messages = collect_chat_messages(page)?;
+                    // 点开会话时页面会拉历史消息，时间基准同样要抢在点击之前取
+                    let chat_since = install_request_recorder(page)?;
+                    if !open_contact(page, &contact.imid)? {
+                        logger::warning(format!(
+                            "猎聘会话「{}」已从列表消失，跳过",
+                            truncate_str(&contact.display_name(), 20)
+                        ))?;
+                        continue;
+                    }
+
+                    let chat_messages = collect_chat_messages(page, chat_since)?;
+
+                    // 对方来要简历就同意，和 Boss 侧"别人请求、我们确认发送"是同一条规则。
+                    // 放在取完消息之后，这条请求本身也会进上下文，回复时 LLM 知道刚同意过
+                    if accept_resume_request(page)? {
+                        logger::info("猎聘对方索要简历，已点同意")?;
+                    }
                     let latest = chat_messages
                         .last()
                         .map(|m| m.text.as_str())
                         .unwrap_or("(空)");
                     logger::info(format!(
-                        "处理猎聘第 {}/{} 个会话，最近消息: {}",
+                        "处理猎聘第 {}/{} 个会话「{}」，最近消息: {}",
                         index + 1,
-                        chats.len(),
+                        total,
+                        truncate_str(&contact.display_name(), 20),
                         truncate_str(latest, 30)
                     ))?;
 
@@ -74,110 +149,354 @@ pub async fn reply_unread(config: &AppRuntimeConfig) -> Result<Vec<ChatMessage>,
 
                     sleep_random_ms(2500, 4500);
                 }
-
-                if !scroll_chat_list(page)? {
-                    logger::info("猎聘未读消息已处理完成")?;
-                    return Ok(Vec::new());
-                }
             }
         })
     })
     .await
 }
 
-fn click_unread_filter(page: &Page) -> Result<(), anyhow::Error> {
-    for selector in [
-        "[class*='unread']",
-        "button[class*='unread']",
-        "span[class*='unread']",
-        ".message-filter-unread",
-    ] {
-        if let Some(ele) = page.ele(selector)? {
-            ele.click()?;
-            sleep_random_ms(500, 800);
-            return Ok(());
+/// 打开右侧会话抽屉，返回抓包的时间基准。
+///
+/// 首页水合完成前点入口，轻则抽屉不弹，重则触发一次整页重载（两种都实测到过）。
+/// 重载会把页面里的请求记录器一起冲掉，所以记录器必须每次点击前重挂一遍，
+/// 返回的基准也只能取自真正打开抽屉的那一次点击。
+fn open_chat_drawer(page: &Page) -> Result<f64, anyhow::Error> {
+    for attempt in 1..=OPEN_DRAWER_RETRIES {
+        page.wait(CHAT_ENTRY, Duration::from_secs(15))
+            .context("没找到猎聘沟通入口，请确认已登录候选人端")?;
+        sleep_random_ms(1200, 1800);
+
+        let since = install_request_recorder(page)?;
+        page.click(CHAT_ENTRY)?;
+
+        if page.wait(CONTACT_ITEM, Duration::from_secs(10)).is_ok() {
+            sleep_random_ms(600, 1000);
+            return Ok(since);
         }
+
+        logger::warning(format!(
+            "猎聘会话列表没打开（第 {}/{} 次），重试",
+            attempt, OPEN_DRAWER_RETRIES
+        ))?;
     }
-    Ok(())
+
+    Err(anyhow::anyhow!("猎聘会话抽屉打不开，已重试多次"))
 }
 
-fn collect_chat_cards(page: &Page) -> Result<Vec<Element>, anyhow::Error> {
-    for selector in [
-        ".chat-list-item",
-        ".message-list-item",
-        "[class*='chat-item']",
-        "[class*='message-item']",
-        "li[class*='session']",
-    ] {
-        let cards = page.eles(selector)?;
-        if !cards.is_empty() {
-            return Ok(cards);
-        }
-    }
-    Ok(Vec::new())
+#[derive(Debug, Clone)]
+struct UnreadContact {
+    /// 会话唯一 id。接口里叫 `oppositeImId`，DOM 埋点里叫 `data-tlg-ext.to_imid`，
+    /// 实测两者是同一个值，所以接口取数、DOM 点击可以混用
+    imid: String,
+    name: String,
+    company: String,
 }
 
-fn click_resume_action(page: &Page) -> Result<(), anyhow::Error> {
-    for selector in [
-        ".send-resume",
-        ".resume-btn",
-        "button[class*='resume']",
-        "a[class*='resume']",
-        "button[class*='confirm']",
-    ] {
-        if let Some(ele) = page.ele(selector)? {
-            ele.click()?;
-            sleep_random_ms(500, 800);
-            click_confirm_if_present(page)?;
-            return Ok(());
+impl UnreadContact {
+    fn display_name(&self) -> String {
+        if self.company.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}·{}", self.name, self.company)
         }
     }
-    Ok(())
 }
 
-fn click_confirm_if_present(page: &Page) -> Result<(), anyhow::Error> {
-    for selector in [
-        ".ant-modal-confirm-btns .ant-btn-primary",
-        ".modal .confirm",
-        "button[class*='confirm']",
-        "button[class*='sure']",
-    ] {
-        if let Some(ele) = page.ele(selector)? {
-            ele.click()?;
-            sleep_random_ms(500, 800);
-            return Ok(());
+/// 数据来源，用来在日志里说清这一轮是接口还是页面元素给的
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Source {
+    Api,
+    Dom,
+}
+
+impl Source {
+    fn label(self) -> &'static str {
+        match self {
+            Source::Api => "接口",
+            Source::Dom => "页面元素",
         }
     }
-    Ok(())
 }
 
-fn collect_chat_messages(page: &Page) -> Result<Vec<ChatMessage>, anyhow::Error> {
+/// 取未读会话：优先用接口响应，拿不到再退回 DOM。
+///
+/// 接口给的是精确的 `unReadCnt`；DOM 兜底看的是红色角标 `ant-im-badge-count`。
+/// 两条路都不碰会话摘要里那个 `[未读]`（`im-ui-message-read-status`）——
+/// 它表示"我方发出的消息对方还没看"，语义相反，用它会把所有已回复的会话又发一遍。
+fn collect_unread_contacts(
+    page: &Page,
+    since: f64,
+) -> Result<(Vec<UnreadContact>, Source), anyhow::Error> {
+    // 列表翻到底时页面本来就不会再发请求，读不到不算异常，静默回落即可
+    if let Some(body) = read_api_body(page, CONTACT_LIST_API, since)? {
+        match parse_unread_contacts(&body) {
+            Ok(contacts) => return Ok((contacts, Source::Api)),
+            Err(error) => logger::warning(format!(
+                "猎聘会话列表接口解析失败，改用页面元素: {}",
+                error
+            ))?,
+        }
+    }
+
+    Ok((collect_unread_contacts_from_dom(page)?, Source::Dom))
+}
+
+fn parse_unread_contacts(body: &str) -> Result<Vec<UnreadContact>, anyhow::Error> {
+    let response: ContactListResponse =
+        serde_json::from_str(body).context("会话列表响应不是预期的 JSON")?;
+
+    Ok(response
+        .data
+        .map(|data| data.list)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|contact| contact.un_read_cnt > 0 && !contact.opposite_im_id.is_empty())
+        .map(|contact| UnreadContact {
+            imid: contact.opposite_im_id,
+            name: contact.name,
+            company: contact.company,
+        })
+        .collect())
+}
+
+fn collect_unread_contacts_from_dom(page: &Page) -> Result<Vec<UnreadContact>, anyhow::Error> {
     let value = page
         .run_js_await(
             r#"
             (() => {
-                const selectors = [
-                    ".message-content",
-                    ".chat-message",
-                    "[class*='message-content']",
-                    "[class*='bubble']",
-                    "[class*='chat-msg']"
-                ];
-                const nodes = selectors.flatMap((selector) => Array.from(document.querySelectorAll(selector)));
-                const seen = new Set();
-                return nodes.map((node, index) => {
-                    const text = (node.innerText || node.textContent || "").trim();
-                    if (!text || seen.has(text + index)) return null;
-                    seen.add(text + index);
-                    const className = node.className || "";
-                    return {
+                const items = Array.from(document.querySelectorAll(".im-ui-contact-list-item"));
+                return items.map((item) => {
+                    let ext = {};
+                    try {
+                        ext = JSON.parse(decodeURIComponent(item.getAttribute("data-tlg-ext") || "")) || {};
+                    } catch (e) {}
+                    const unread = !!item.querySelector(".ant-im-badge-count") || ext.unread === true;
+                    const imid = String(ext.to_imid || "");
+                    if (!unread || !imid) return null;
+                    const info = item.querySelector(".im-ui-contact-item-info");
+                    const lines = ((info && info.innerText) || "")
+                        .split("\n")
+                        .map((line) => line.trim())
+                        .filter(Boolean);
+                    return { imid, name: lines[0] || "", company: "" };
+                }).filter(Boolean);
+            })()
+            "#,
+        )
+        .context("读取猎聘未读会话失败")?;
+
+    let raw = value.get("value").cloned().unwrap_or(value);
+    let contacts: Vec<DomContact> =
+        serde_json::from_value(raw).context("解析猎聘未读会话失败")?;
+
+    Ok(contacts
+        .into_iter()
+        .map(|contact| UnreadContact {
+            imid: contact.imid,
+            name: contact.name,
+            company: contact.company,
+        })
+        .collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct DomContact {
+    imid: String,
+    name: String,
+    company: String,
+}
+
+/// 按会话 id 点开聊天窗。返回 false 表示卡片已经不在列表里（被新消息挤走或列表重排）
+fn open_contact(page: &Page, imid: &str) -> Result<bool, anyhow::Error> {
+    // imid 是十六进制串，URL 编码后原样保留，可以直接做属性子串匹配
+    let selector = format!("{}[data-tlg-ext*='{}']", CONTACT_ITEM, imid);
+    let Some(card) = page.ele(&selector)? else {
+        return Ok(false);
+    };
+
+    card.click()?;
+    page.wait(MSG_LIST, Duration::from_secs(10))
+        .context("猎聘聊天窗加载超时")?;
+    sleep_random_ms(800, 1200);
+    Ok(true)
+}
+
+/// HR 主动索要简历时会推一张卡片（payload 里 `extType` = 206），带【拒绝】【同意】两个按钮。
+/// 同意即把简历发过去 —— 这是对方发起、我们确认，和主动给每个 HR 投简历是两回事。
+///
+/// 只认文案里带"简历"的那张卡：优先沟通、职位卡片长得一样，光靠按钮会误点。
+/// 已经处理过的卡片不再有可点的【同意】，所以按钮还在就说明这次是待处理的。
+///
+/// 点完就发出去了，没有二次确认 —— 实测过。不要照 Boss 那边补 `.panel-resume` 的等待，
+/// 猎聘这里没有那个弹窗，等只会白等到超时。
+fn accept_resume_request(page: &Page) -> Result<bool, anyhow::Error> {
+    let value = page
+        .run_js_await(
+            r#"
+            (() => {
+                const cards = Array.from(document.querySelectorAll(".im-ui-common-message-card"));
+                // 同一个会话可能来过多次，从最新的一张往回找
+                for (const card of cards.reverse()) {
+                    if (!(card.innerText || "").includes("简历")) continue;
+                    const button = card.querySelector("button[btntext='同意']");
+                    if (!button || button.disabled) continue;
+                    button.setAttribute("data-fj-agree", "1");
+                    return true;
+                }
+                return false;
+            })()
+            "#,
+        )
+        .context("查找猎聘简历请求卡片失败")?;
+
+    let raw = value.get("value").cloned().unwrap_or(value);
+    if !raw.as_bool().unwrap_or(false) {
+        return Ok(false);
+    }
+
+    // 标记出来再用真实点击，比在页面里直接 click 更接近人的操作
+    page.click("button[data-fj-agree='1']")?;
+    sleep_random_ms(800, 1200);
+    Ok(true)
+}
+
+/// 取聊天记录：优先用接口响应，拿不到再退回 DOM
+fn collect_chat_messages(page: &Page, since: f64) -> Result<Vec<ChatMessage>, anyhow::Error> {
+    match read_api_body(page, CHAT_LIST_API, since)? {
+        Some(body) => match parse_chat_messages(&body) {
+            Ok(messages) if !messages.is_empty() => Ok(messages),
+            // 整段都是系统提示/营销卡时会解析成空，这时 DOM 也给不出更多，直接返回空
+            Ok(messages) => Ok(messages),
+            Err(error) => {
+                logger::warning(format!("猎聘聊天记录接口解析失败，改用页面元素: {}", error))?;
+                collect_chat_messages_from_dom(page)
+            }
+        },
+        None => {
+            logger::warning("猎聘聊天记录接口未捕获，改用页面元素")?;
+            collect_chat_messages_from_dom(page)
+        }
+    }
+}
+
+/// 解析 `com.liepin.im.c.chat.chat-list` 响应。
+///
+/// 几个坑：接口按时间倒序返回，要反转成正序；`payload` 是被转义了一层的 JSON 字符串，
+/// 得二次解析；卡片类消息的 `msgType` 也是 `txt`，只能靠 `ext.extType` 区分。
+pub(crate) fn parse_chat_messages(body: &str) -> Result<Vec<ChatMessage>, anyhow::Error> {
+    let response: ChatListResponse =
+        serde_json::from_str(body).context("聊天记录响应不是预期的 JSON")?;
+
+    let mut messages: Vec<ChatMessage> = response
+        .data
+        .map(|data| data.list)
+        .unwrap_or_default()
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, record)| {
+            if record.revoke_flag {
+                return None;
+            }
+
+            let payload: MessagePayload = serde_json::from_str(&record.payload).ok()?;
+            let text = payload_text(&payload)?;
+
+            Some(ChatMessage {
+                // 雪花 id 超出 JS 安全整数所以接口发的是字符串，i64 装得下
+                mid: record.msg_id.parse::<i64>().unwrap_or(index as i64),
+                // direction: "0" 是自己发的，"1" 是对方发来的
+                received: record.direction == "1",
+                text,
+                time: record.msg_time,
+                from_name: String::new(),
+            })
+        })
+        .collect();
+
+    // 接口是新→旧，模板匹配和 LLM 都按旧→新读
+    messages.reverse();
+    Ok(messages)
+}
+
+/// 把 payload 还原成一句能喂给模板/LLM 的话。
+/// 返回 None 表示这条不该进上下文（系统提示、营销卡片、空消息）。
+fn payload_text(payload: &MessagePayload) -> Option<String> {
+    let ext_type = payload.ext.as_ref().map(|ext| ext.ext_type).unwrap_or(1);
+    let biz_data = payload
+        .ext
+        .as_ref()
+        .and_then(|ext| ext.ext_body.as_ref())
+        .and_then(|body| body.biz_data.as_ref());
+
+    match ext_type {
+        // 岗位卡片：占位符是"[职位卡片]"，没有信息量，换成真正的岗位信息
+        201 => {
+            let job = biz_data?;
+            let title = job.job_title.as_deref().unwrap_or_default().trim();
+            if title.is_empty() {
+                return None;
+            }
+            let mut text = format!("[职位] {}", title);
+            if let Some(company) = job.job_company.as_deref().map(str::trim).filter(|v| !v.is_empty())
+            {
+                text.push_str(&format!("｜{}", company));
+            }
+            if let Some(salary) = job.job_salary.as_deref().map(str::trim).filter(|v| !v.is_empty())
+            {
+                text.push_str(&format!("｜{}", salary));
+            }
+            Some(text)
+        }
+        // 200 系统提示（"您向对方发起沟通"、防诈骗提醒）、214 优先沟通营销卡，都是噪音
+        200 | 214 => None,
+        _ => {
+            let body = payload.bodies.first()?;
+            if body.body_type == "img" {
+                // 图片没有 msg 字段，用文件名比"[图片]"更有信息量
+                return Some(match body.filename.as_deref().map(str::trim) {
+                    Some(name) if !name.is_empty() => format!("[图片] {}", name),
+                    _ => "[图片]".to_string(),
+                });
+            }
+            let text = body.msg.as_deref().unwrap_or_default().trim();
+            if text.is_empty() {
+                None
+            } else {
+                Some(text.to_string())
+            }
+        }
+    }
+}
+
+fn collect_chat_messages_from_dom(page: &Page) -> Result<Vec<ChatMessage>, anyhow::Error> {
+    let value = page
+        .run_js_await(
+            r#"
+            (() => {
+                const list = document.querySelector(".im-ui-msg-list-content");
+                if (!list) return [];
+                const messages = [];
+                Array.from(list.querySelectorAll(".im-ui-message-item")).forEach((node, index) => {
+                    // 安全提示、"您向对方发起沟通"、运营卡片都没有 send/receive 主体，不是真实对话
+                    const body = node.querySelector(
+                        ".im-ui-message-item-send, .im-ui-message-item-receive"
+                    );
+                    if (!body) return;
+                    const received = body.classList.contains("im-ui-message-item-receive");
+                    const txt = body.querySelector(".im-ui-txt");
+                    let text = txt ? (txt.innerText || "").trim() : "";
+                    if (!text && body.querySelector(".im-ui-img-message")) text = "[图片]";
+                    if (!text) text = (body.innerText || "").trim();
+                    if (!text) return;
+                    messages.push({
                         mid: index,
-                        received: !/self|mine|right|me/.test(String(className)),
+                        received,
                         text,
                         time: Date.now(),
                         from_name: ""
-                    };
-                }).filter(Boolean);
+                    });
+                });
+                return messages;
             })()
             "#,
         )
@@ -188,6 +507,146 @@ fn collect_chat_messages(page: &Page) -> Result<Vec<ChatMessage>, anyhow::Error>
         serde_json::from_value::<Vec<ChatMessage>>(raw).context("解析猎聘聊天记录失败")?;
 
     Ok(messages)
+}
+
+/// 从页面的请求记录里捞 `since` 之后这个接口的最后一条成功响应，捞不到返回 None。
+///
+/// 记录器只收 POST，猎聘 IM 接口都是 POST；同一个会话反复点开会有多条记录，取最后一条。
+fn read_api_body(page: &Page, api: &str, since: f64) -> Result<Option<String>, anyhow::Error> {
+    let script = format!(
+        r#"
+        (async () => {{
+            const since = {since};
+            const api = {api};
+            const deadline = performance.now() + {API_WAIT_MS};
+            const pick = () => (window.__fjRequestRecords || [])
+                .filter((item) => item.at > since
+                    && item.status >= 200 && item.status < 300
+                    && String(item.url || "").includes(api)
+                    && item.body)
+                .pop();
+
+            let hit = pick();
+            while (!hit && performance.now() < deadline) {{
+                await new Promise((resolve) => setTimeout(resolve, 200));
+                hit = pick();
+            }}
+            return hit ? hit.body : "";
+        }})()
+        "#,
+        since = since,
+        api = serde_json::to_string(api).unwrap_or_else(|_| "\"\"".to_string()),
+    );
+
+    let value = page
+        .run_js_await(&script)
+        .with_context(|| format!("读取猎聘 {} 响应失败", api))?;
+    let raw = value.get("value").cloned().unwrap_or(value);
+    let body = raw.as_str().unwrap_or_default().to_string();
+
+    Ok(if body.is_empty() { None } else { Some(body) })
+}
+
+#[derive(Debug, Deserialize)]
+struct ContactListResponse {
+    data: Option<ContactListData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContactListData {
+    #[serde(default)]
+    list: Vec<ContactRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ContactRecord {
+    #[serde(default)]
+    opposite_im_id: String,
+    #[serde(default)]
+    un_read_cnt: i64,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    company: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatListResponse {
+    data: Option<ChatListData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatListData {
+    #[serde(default)]
+    list: Vec<ChatRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ChatRecord {
+    #[serde(default)]
+    msg_id: String,
+    /// "0" 自己发出，"1" 对方发来。接口给的是字符串不是数字
+    #[serde(default)]
+    direction: String,
+    #[serde(default)]
+    msg_time: i64,
+    /// 转义了一层的 JSON 字符串
+    #[serde(default)]
+    payload: String,
+    #[serde(default)]
+    revoke_flag: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct MessagePayload {
+    #[serde(default)]
+    bodies: Vec<PayloadBody>,
+    #[serde(default)]
+    ext: Option<PayloadExt>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PayloadBody {
+    #[serde(default, rename = "type")]
+    body_type: String,
+    #[serde(default)]
+    msg: Option<String>,
+    #[serde(default)]
+    filename: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PayloadExt {
+    /// 1 普通消息，200 系统提示，201 岗位卡片，214 优先沟通卡
+    #[serde(default = "default_ext_type")]
+    ext_type: i64,
+    #[serde(default)]
+    ext_body: Option<PayloadExtBody>,
+}
+
+fn default_ext_type() -> i64 {
+    1
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PayloadExtBody {
+    #[serde(default)]
+    biz_data: Option<BizData>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BizData {
+    #[serde(default)]
+    job_title: Option<String>,
+    #[serde(default)]
+    job_company: Option<String>,
+    #[serde(default)]
+    job_salary: Option<String>,
 }
 
 async fn resolve_reply_resources(
@@ -253,35 +712,27 @@ fn latest_chat_history(chat_messages: &[ChatMessage], limit: i32) -> String {
         .join("\n")
 }
 
-fn scroll_chat_list(page: &Page) -> Result<bool, anyhow::Error> {
-    let before = page.run_js_await(
+/// 会话列表的滚动容器是 `im-ui-contacts-wrap` 里一个没有 class 的 div，
+/// 只能从会话卡往上找第一个能滚的祖先
+fn scroll_contact_list(page: &Page) -> Result<bool, anyhow::Error> {
+    let value = page.run_js_await(
         r#"
-        (() => {
-            const el = document.querySelector("[class*='list']") || document.scrollingElement;
-            return el ? el.scrollTop : 0;
+        (async () => {
+            const item = document.querySelector(".im-ui-contact-list-item");
+            if (!item) return false;
+            let el = item;
+            while (el && el.scrollHeight <= el.clientHeight + 5) el = el.parentElement;
+            if (!el) return false;
+            const before = el.scrollTop;
+            el.scrollTop += el.clientHeight;
+            await new Promise((resolve) => setTimeout(resolve, 800));
+            return el.scrollTop !== before;
         })()
         "#,
     )?;
-    page.run_js_await(
-        r#"
-        (() => {
-            const el = document.querySelector("[class*='list']") || document.scrollingElement;
-            if (!el) return 0;
-            el.scrollTop += 500;
-            return el.scrollTop;
-        })()
-        "#,
-    )?;
-    std::thread::sleep(Duration::from_millis(600));
-    let after = page.run_js_await(
-        r#"
-        (() => {
-            const el = document.querySelector("[class*='list']") || document.scrollingElement;
-            return el ? el.scrollTop : 0;
-        })()
-        "#,
-    )?;
-    Ok(before != after)
+
+    let raw = value.get("value").cloned().unwrap_or(value);
+    Ok(raw.as_bool().unwrap_or(false))
 }
 
 fn truncate_str(s: &str, max_len: usize) -> &str {
@@ -294,5 +745,128 @@ fn truncate_str(s: &str, max_len: usize) -> &str {
             .map(|(i, _)| i)
             .unwrap_or(s.len());
         &s[..end]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_contacts_with_unread_count_are_returned() {
+        let body = r#"{
+            "flag": 1,
+            "data": {
+                "list": [
+                    {"oppositeImId":"aaa","unReadCnt":0,"name":"张女士","company":"甲公司"},
+                    {"oppositeImId":"bbb","unReadCnt":2,"name":"姜女士","company":"乙公司"},
+                    {"oppositeImId":"","unReadCnt":5,"name":"没有会话 id","company":""}
+                ]
+            }
+        }"#;
+
+        let contacts = parse_unread_contacts(body).unwrap();
+
+        assert_eq!(contacts.len(), 1);
+        assert_eq!(contacts[0].imid, "bbb");
+        assert_eq!(contacts[0].display_name(), "姜女士·乙公司");
+    }
+
+    /// direction 是字符串 "0"/"1"，且接口按时间倒序下发
+    #[test]
+    fn messages_are_reordered_and_direction_is_mapped() {
+        let body = r#"{
+            "data": {
+                "list": [
+                    {"msgId":"1363464068980146182","direction":"1","msgTime":1786588521000,
+                     "payload":"{\"bodies\":[{\"type\":\"txt\",\"msg\":\"周期一年的项目考虑吗\"}],\"ext\":{\"extType\":1}}"},
+                    {"msgId":"1363464068980146100","direction":"0","msgTime":1786538091000,
+                     "payload":"{\"bodies\":[{\"type\":\"txt\",\"msg\":\"你好，岗位还在招吗\"}],\"ext\":{\"extType\":1}}"}
+                ]
+            }
+        }"#;
+
+        let messages = parse_chat_messages(body).unwrap();
+
+        assert_eq!(messages.len(), 2);
+        // 旧的排前面
+        assert_eq!(messages[0].text, "你好，岗位还在招吗");
+        assert!(!messages[0].received, "direction=0 是自己发的");
+        assert_eq!(messages[1].text, "周期一年的项目考虑吗");
+        assert!(messages[1].received, "direction=1 是对方发来的");
+        assert_eq!(messages[1].mid, 1363464068980146182);
+        assert_eq!(messages[1].time, 1786588521000);
+    }
+
+    /// 卡片消息的 msgType 也是 txt，只能靠 extType 区分
+    #[test]
+    fn system_and_marketing_cards_are_dropped_but_job_card_is_kept() {
+        let body = r#"{
+            "data": {
+                "list": [
+                    {"msgId":"4","direction":"0","msgTime":4,
+                     "payload":"{\"bodies\":[{\"type\":\"txt\",\"msg\":\"[优先沟通]\"}],\"ext\":{\"extType\":214}}"},
+                    {"msgId":"3","direction":"0","msgTime":3,
+                     "payload":"{\"bodies\":[{\"type\":\"txt\",\"msg\":\"[职位卡片]\"}],\"ext\":{\"extType\":201,\"extBody\":{\"bizData\":{\"jobTitle\":\"AI应用工程师\",\"jobCompany\":\"宏远科创\",\"jobSalary\":\"8-14k\"}}}}"},
+                    {"msgId":"2","direction":"0","msgTime":2,
+                     "payload":"{\"bodies\":[{\"type\":\"img\",\"filename\":\"简历图片.png\"}],\"ext\":{\"extType\":1}}"},
+                    {"msgId":"1","direction":"0","msgTime":1,
+                     "payload":"{\"bodies\":[{\"type\":\"txt\",\"msg\":\"您向对方发起沟通\"}],\"ext\":{\"extType\":200}}"}
+                ]
+            }
+        }"#;
+
+        let texts: Vec<String> = parse_chat_messages(body)
+            .unwrap()
+            .into_iter()
+            .map(|message| message.text)
+            .collect();
+
+        assert_eq!(
+            texts,
+            vec!["[图片] 简历图片.png", "[职位] AI应用工程师｜宏远科创｜8-14k"]
+        );
+    }
+
+    /// 对方索要简历是 extType=206，正文就是那句问话，必须留在上下文里，
+    /// 否则回复时看不出刚刚同意过发简历
+    #[test]
+    fn resume_request_card_stays_in_context() {
+        let body = r#"{
+            "data": {
+                "list": [
+                    {"msgId":"1","direction":"1","msgTime":1,
+                     "payload":"{\"bodies\":[{\"type\":\"txt\",\"msg\":\"我想要一份你的简历，你是否同意？\"}],\"ext\":{\"extType\":206,\"extBody\":{\"bizType\":\"7\",\"bizData\":{\"bizKey\":\"20003\",\"status\":\"1\"}}},\"push\":\"1\"}"}
+                ]
+            }
+        }"#;
+
+        let messages = parse_chat_messages(body).unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].text, "我想要一份你的简历，你是否同意？");
+        assert!(messages[0].received);
+    }
+
+    #[test]
+    fn revoked_messages_are_skipped() {
+        let body = r#"{
+            "data": {
+                "list": [
+                    {"msgId":"1","direction":"1","msgTime":1,"revokeFlag":true,
+                     "payload":"{\"bodies\":[{\"type\":\"txt\",\"msg\":\"说错了\"}],\"ext\":{\"extType\":1}}"}
+                ]
+            }
+        }"#;
+
+        assert!(parse_chat_messages(body).unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_payload_list_is_not_an_error() {
+        assert!(parse_chat_messages(r#"{"flag":1,"data":{"list":[]}}"#)
+            .unwrap()
+            .is_empty());
+        assert!(parse_unread_contacts(r#"{"flag":1}"#).unwrap().is_empty());
     }
 }

--- a/src-tauri/src/rpa/liepin/handler/reply_unread.rs
+++ b/src-tauri/src/rpa/liepin/handler/reply_unread.rs
@@ -45,114 +45,118 @@ const OPEN_DRAWER_RETRIES: usize = 3;
 pub async fn reply_unread(config: &AppRuntimeConfig) -> Result<Vec<ChatMessage>, anyhow::Error> {
     let config = config.clone();
 
-    browser::with_new_tab(|page| {
-        Box::pin(async move {
-            logger::info("正在打开猎聘沟通面板")?;
-            page.get(LIEPIN_USER_HOME_URL)?;
+    browser::with_new_tab(|page| Box::pin(async move { reply_unread_on_page(page, &config).await }))
+        .await
+}
 
-            // 会话列表是抽屉打开那一刻才拉的，记录器必须赶在那次点击之前挂上
-            let mut since = open_chat_drawer(page)?;
+/// Process Liepin unread conversations on a caller-owned task tab.
+pub async fn reply_unread_on_page(
+    page: &Page,
+    config: &AppRuntimeConfig,
+) -> Result<Vec<ChatMessage>, anyhow::Error> {
+    let config = config.clone();
+    logger::info("正在打开猎聘沟通面板")?;
+    page.get(LIEPIN_USER_HOME_URL)?;
 
-            let replay_config = config.replay_config.clone();
-            // 处理完的会话未读角标会消失，但列表会随新消息重排，
-            // 用会话 id 去重才不会漏处理或重复处理
-            let mut handled: HashSet<String> = HashSet::new();
-            let mut scrolled = 0usize;
+    // 会话列表是抽屉打开那一刻才拉的，记录器必须赶在那次点击之前挂上
+    let mut since = open_chat_drawer(page)?;
 
-            loop {
-                if is_job_task_stop_requested() {
-                    logger::info("猎聘沟通任务已结束")?;
-                    return Ok(Vec::new());
-                }
+    let replay_config = config.replay_config.clone();
+    // 处理完的会话未读角标会消失，但列表会随新消息重排，
+    // 用会话 id 去重才不会漏处理或重复处理
+    let mut handled: HashSet<String> = HashSet::new();
+    let mut scrolled = 0usize;
 
-                let (contacts, source) = collect_unread_contacts(page, since)?;
-                let pending: Vec<UnreadContact> = contacts
-                    .into_iter()
-                    .filter(|contact| !handled.contains(&contact.imid))
-                    .collect();
+    loop {
+        if is_job_task_stop_requested() {
+            logger::info("猎聘沟通任务已结束")?;
+            return Ok(Vec::new());
+        }
 
-                if pending.is_empty() {
-                    if scrolled >= MAX_SCROLL_ROUNDS {
-                        logger::info("猎聘会话列表已翻到上限，停止查找")?;
-                        return Ok(Vec::new());
-                    }
-                    // 滚动会触发下一页会话列表，时间基准要往前推，免得读到上一次的响应
-                    since = install_request_recorder(page)?;
-                    if !scroll_contact_list(page)? {
-                        if handled.is_empty() {
-                            logger::info("猎聘没有未读消息")?;
-                        } else {
-                            logger::info(format!(
-                                "猎聘未读消息已处理完成，共 {} 个会话",
-                                handled.len()
-                            ))?;
-                        }
-                        return Ok(Vec::new());
-                    }
-                    scrolled += 1;
-                    continue;
-                }
+        let (contacts, source) = collect_unread_contacts(page, since)?;
+        let pending: Vec<UnreadContact> = contacts
+            .into_iter()
+            .filter(|contact| !handled.contains(&contact.imid))
+            .collect();
 
-                logger::info(format!(
-                    "猎聘当前未读会话数: {}（取自{}）",
-                    pending.len(),
-                    source.label()
-                ))?;
-                let total = pending.len();
-                for (index, contact) in pending.into_iter().enumerate() {
-                    if is_job_task_stop_requested() {
-                        logger::info("猎聘沟通任务已结束")?;
-                        return Ok(Vec::new());
-                    }
-
-                    // 先记账再点击：这一轮无论成功失败都不再重试同一个会话，避免死循环
-                    handled.insert(contact.imid.clone());
-
-                    // 点开会话时页面会拉历史消息，时间基准同样要抢在点击之前取
-                    let chat_since = install_request_recorder(page)?;
-                    if !open_contact(page, &contact.imid)? {
-                        logger::warning(format!(
-                            "猎聘会话「{}」已从列表消失，跳过",
-                            truncate_str(&contact.display_name(), 20)
-                        ))?;
-                        continue;
-                    }
-
-                    let chat_messages = collect_chat_messages(page, chat_since)?;
-
-                    // 对方来要简历就同意，和 Boss 侧"别人请求、我们确认发送"是同一条规则。
-                    // 放在取完消息之后，这条请求本身也会进上下文，回复时 LLM 知道刚同意过
-                    if accept_resume_request(page)? {
-                        logger::info("猎聘对方索要简历，已点同意")?;
-                    }
-                    let latest = chat_messages
-                        .last()
-                        .map(|m| m.text.as_str())
-                        .unwrap_or("(空)");
-                    logger::info(format!(
-                        "处理猎聘第 {}/{} 个会话「{}」，最近消息: {}",
-                        index + 1,
-                        total,
-                        truncate_str(&contact.display_name(), 20),
-                        truncate_str(latest, 30)
-                    ))?;
-
-                    if let Some(resources) =
-                        resolve_reply_resources(&config, &replay_config.templates, &chat_messages)
-                            .await?
-                    {
-                        send_resources(page, resources)?;
-                        logger::info("猎聘回复消息已发送")?;
-                    } else {
-                        logger::info("猎聘未匹配到回复模板，跳过")?;
-                    }
-
-                    sleep_random_ms(2500, 4500);
-                }
+        if pending.is_empty() {
+            if scrolled >= MAX_SCROLL_ROUNDS {
+                logger::info("猎聘会话列表已翻到上限，停止查找")?;
+                return Ok(Vec::new());
             }
-        })
-    })
-    .await
+            // 滚动会触发下一页会话列表，时间基准要往前推，免得读到上一次的响应
+            since = install_request_recorder(page)?;
+            if !scroll_contact_list(page)? {
+                if handled.is_empty() {
+                    logger::info("猎聘没有未读消息")?;
+                } else {
+                    logger::info(format!(
+                        "猎聘未读消息已处理完成，共 {} 个会话",
+                        handled.len()
+                    ))?;
+                }
+                return Ok(Vec::new());
+            }
+            scrolled += 1;
+            continue;
+        }
+
+        logger::info(format!(
+            "猎聘当前未读会话数: {}（取自{}）",
+            pending.len(),
+            source.label()
+        ))?;
+        let total = pending.len();
+        for (index, contact) in pending.into_iter().enumerate() {
+            if is_job_task_stop_requested() {
+                logger::info("猎聘沟通任务已结束")?;
+                return Ok(Vec::new());
+            }
+
+            // 先记账再点击：这一轮无论成功失败都不再重试同一个会话，避免死循环
+            handled.insert(contact.imid.clone());
+
+            // 点开会话时页面会拉历史消息，时间基准同样要抢在点击之前取
+            let chat_since = install_request_recorder(page)?;
+            if !open_contact(page, &contact.imid)? {
+                logger::warning(format!(
+                    "猎聘会话「{}」已从列表消失，跳过",
+                    truncate_str(&contact.display_name(), 20)
+                ))?;
+                continue;
+            }
+
+            let chat_messages = collect_chat_messages(page, chat_since)?;
+
+            // 对方来要简历就同意，和 Boss 侧"别人请求、我们确认发送"是同一条规则。
+            // 放在取完消息之后，这条请求本身也会进上下文，回复时 LLM 知道刚同意过
+            if accept_resume_request(page)? {
+                logger::info("猎聘对方索要简历，已点同意")?;
+            }
+            let latest = chat_messages
+                .last()
+                .map(|m| m.text.as_str())
+                .unwrap_or("(空)");
+            logger::info(format!(
+                "处理猎聘第 {}/{} 个会话「{}」，最近消息: {}",
+                index + 1,
+                total,
+                truncate_str(&contact.display_name(), 20),
+                truncate_str(latest, 30)
+            ))?;
+
+            if let Some(resources) =
+                resolve_reply_resources(&config, &replay_config.templates, &chat_messages).await?
+            {
+                send_resources(page, resources)?;
+                logger::info("猎聘回复消息已发送")?;
+            } else {
+                logger::info("猎聘未匹配到回复模板，跳过")?;
+            }
+
+            sleep_random_ms(2500, 4500);
+        }
+    }
 }
 
 /// 打开右侧会话抽屉，返回抓包的时间基准。
@@ -231,10 +235,9 @@ fn collect_unread_contacts(
     if let Some(body) = read_api_body(page, CONTACT_LIST_API, since)? {
         match parse_unread_contacts(&body) {
             Ok(contacts) => return Ok((contacts, Source::Api)),
-            Err(error) => logger::warning(format!(
-                "猎聘会话列表接口解析失败，改用页面元素: {}",
-                error
-            ))?,
+            Err(error) => {
+                logger::warning(format!("猎聘会话列表接口解析失败，改用页面元素: {}", error))?
+            }
         }
     }
 
@@ -286,8 +289,7 @@ fn collect_unread_contacts_from_dom(page: &Page) -> Result<Vec<UnreadContact>, a
         .context("读取猎聘未读会话失败")?;
 
     let raw = value.get("value").cloned().unwrap_or(value);
-    let contacts: Vec<DomContact> =
-        serde_json::from_value(raw).context("解析猎聘未读会话失败")?;
+    let contacts: Vec<DomContact> = serde_json::from_value(raw).context("解析猎聘未读会话失败")?;
 
     Ok(contacts
         .into_iter()
@@ -437,11 +439,19 @@ fn payload_text(payload: &MessagePayload) -> Option<String> {
                 return None;
             }
             let mut text = format!("[职位] {}", title);
-            if let Some(company) = job.job_company.as_deref().map(str::trim).filter(|v| !v.is_empty())
+            if let Some(company) = job
+                .job_company
+                .as_deref()
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
             {
                 text.push_str(&format!("｜{}", company));
             }
-            if let Some(salary) = job.job_salary.as_deref().map(str::trim).filter(|v| !v.is_empty())
+            if let Some(salary) = job
+                .job_salary
+                .as_deref()
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
             {
                 text.push_str(&format!("｜{}", salary));
             }
@@ -824,7 +834,10 @@ mod tests {
 
         assert_eq!(
             texts,
-            vec!["[图片] 简历图片.png", "[职位] AI应用工程师｜宏远科创｜8-14k"]
+            vec![
+                "[图片] 简历图片.png",
+                "[职位] AI应用工程师｜宏远科创｜8-14k"
+            ]
         );
     }
 

--- a/src-tauri/src/rpa/liepin/handler/reply_unread.rs
+++ b/src-tauri/src/rpa/liepin/handler/reply_unread.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use crate::{
     browser,
     config::{AppRuntimeConfig, ReplayResourceType, ReplyResource, ReplyTemplate},
+    dao::{job_detail_dao, model::JobDetail, profile_snapshot_dao},
     logger,
     rpa::{
         common::ChatMessage,
@@ -61,7 +62,6 @@ pub async fn reply_unread_on_page(
     // 会话列表是抽屉打开那一刻才拉的，记录器必须赶在那次点击之前挂上
     let mut since = open_chat_drawer(page)?;
 
-    let replay_config = config.replay_config.clone();
     // 处理完的会话未读角标会消失，但列表会随新消息重排，
     // 用会话 id 去重才不会漏处理或重复处理
     let mut handled: HashSet<String> = HashSet::new();
@@ -145,8 +145,34 @@ pub async fn reply_unread_on_page(
                 truncate_str(latest, 30)
             ))?;
 
-            if let Some(resources) =
-                resolve_reply_resources(&config, &replay_config.templates, &chat_messages).await?
+            let owned_job = resolve_owned_job(&contact, &chat_messages);
+            let (conversation_config, source) =
+                profile_snapshot_dao::resolve_for_job(&config, owned_job.as_ref())
+                    .map_err(anyhow::Error::msg)?;
+            match source {
+                profile_snapshot_dao::ResolutionSource::Snapshot => {}
+                profile_snapshot_dao::ResolutionSource::CurrentProfile => {
+                    logger::warning("猎聘会话的方案快照缺失，按当前同名方案回复")?;
+                }
+                profile_snapshot_dao::ResolutionSource::DefaultProfile => {
+                    logger::warning(format!(
+                        "猎聘会话「{}」无法可靠映射到历史岗位，按默认方案回复",
+                        truncate_str(&contact.display_name(), 20)
+                    ))?;
+                }
+            }
+
+            if !conversation_config.replay_config.enable_auto_replay {
+                logger::info("猎聘会话所属求职方案未启用自动回复，跳过")?;
+                continue;
+            }
+
+            if let Some(resources) = resolve_reply_resources(
+                &conversation_config,
+                &conversation_config.replay_config.templates,
+                &chat_messages,
+            )
+            .await?
             {
                 send_resources(page, resources)?;
                 logger::info("猎聘回复消息已发送")?;
@@ -157,6 +183,36 @@ pub async fn reply_unread_on_page(
             sleep_random_ms(2500, 4500);
         }
     }
+}
+
+/// 猎聘当前接口没有直接给出岗位 ID。只有公司唯一命中，或岗位标题也能从消息中
+/// 明确命中时才建立归属；存在歧义时宁可回退默认方案，不能猜测后自动发送。
+fn resolve_owned_job(contact: &UnreadContact, messages: &[ChatMessage]) -> Option<JobDetail> {
+    if contact.company.trim().is_empty() {
+        return None;
+    }
+    let candidates = job_detail_dao::find_by_company(&contact.company).ok()?;
+    select_owned_job(candidates, messages)
+}
+
+fn select_owned_job(candidates: Vec<JobDetail>, messages: &[ChatMessage]) -> Option<JobDetail> {
+    let liepin = candidates
+        .into_iter()
+        .filter(|job| job.platform.eq_ignore_ascii_case("liepin"))
+        .collect::<Vec<_>>();
+    if liepin.len() == 1 {
+        return liepin.into_iter().next();
+    }
+    let title_matches = liepin
+        .into_iter()
+        .filter(|job| {
+            !job.title.trim().is_empty()
+                && messages
+                    .iter()
+                    .any(|message| message.text.contains(&job.title))
+        })
+        .collect::<Vec<_>>();
+    (title_matches.len() == 1).then(|| title_matches[0].clone())
 }
 
 /// 打开右侧会话抽屉，返回抓包的时间基准。
@@ -762,6 +818,37 @@ fn truncate_str(s: &str, max_len: usize) -> &str {
 mod tests {
     use super::*;
 
+    fn job(id: &str, title: &str) -> JobDetail {
+        JobDetail {
+            id: id.into(),
+            platform: "liepin".into(),
+            source_task_id: None,
+            profile_id: Some(id.into()),
+            profile_name: None,
+            profile_snapshot_id: None,
+            title: title.into(),
+            company_name: "同一家公司".into(),
+            detail: String::new(),
+            salary: String::new(),
+            location: None,
+            is_reply: false,
+            is_send_resume: false,
+            created_at: String::new(),
+            resume_sent_at: None,
+            updated_at: String::new(),
+        }
+    }
+
+    fn message(text: &str) -> ChatMessage {
+        ChatMessage {
+            mid: 1,
+            received: true,
+            text: text.into(),
+            time: 1,
+            from_name: String::new(),
+        }
+    }
+
     #[test]
     fn only_contacts_with_unread_count_are_returned() {
         let body = r#"{
@@ -881,5 +968,18 @@ mod tests {
             .unwrap()
             .is_empty());
         assert!(parse_unread_contacts(r#"{"flag":1}"#).unwrap().is_empty());
+    }
+
+    #[test]
+    fn ambiguous_company_never_guesses_job_ownership() {
+        let candidates = vec![job("one", "Rust 工程师"), job("two", "Java 工程师")];
+        assert!(select_owned_job(candidates, &[message("方便聊聊吗")]).is_none());
+    }
+
+    #[test]
+    fn ambiguous_company_can_use_unique_explicit_job_title() {
+        let candidates = vec![job("one", "Rust 工程师"), job("two", "Java 工程师")];
+        let selected = select_owned_job(candidates, &[message("Rust 工程师岗位方便聊聊吗")]);
+        assert_eq!(selected.map(|job| job.id), Some("one".into()));
     }
 }

--- a/src-tauri/src/rpa/liepin/mod.rs
+++ b/src-tauri/src/rpa/liepin/mod.rs
@@ -2,8 +2,10 @@ pub mod handler;
 
 pub const LIEPIN_SITE_URL: &str = "https://www.liepin.com";
 pub const LIEPIN_LOGIN_PAGE_URL: &str = "https://www.liepin.com/simple-login/####";
-pub const LIEPIN_CHAT_URL: &str = "https://www.liepin.com/message/";
-/// 候选人端主页。用户信息接口只接受来自这个域的请求，登录校验必须站在这里发起
+/// 候选人端主页。用户信息接口只接受来自这个域的请求，登录校验必须站在这里发起。
+///
+/// 沟通也在这个页面：猎聘 C 端没有独立聊天页
+/// （`www.liepin.com/message/` 实测 404），会话是首页右侧的抽屉面板。
 pub const LIEPIN_USER_HOME_URL: &str = "https://c.liepin.com";
 pub const LIEPIN_USER_PROPERTY_API: &str =
     "https://api-c.liepin.com/api/com.liepin.usercx.pc.user.base-property";

--- a/src-tauri/src/rpa/liepin/mod.rs
+++ b/src-tauri/src/rpa/liepin/mod.rs
@@ -3,3 +3,7 @@ pub mod handler;
 pub const LIEPIN_SITE_URL: &str = "https://www.liepin.com";
 pub const LIEPIN_LOGIN_PAGE_URL: &str = "https://www.liepin.com/simple-login/####";
 pub const LIEPIN_CHAT_URL: &str = "https://www.liepin.com/message/";
+/// 候选人端主页。用户信息接口只接受来自这个域的请求，登录校验必须站在这里发起
+pub const LIEPIN_USER_HOME_URL: &str = "https://c.liepin.com";
+pub const LIEPIN_USER_PROPERTY_API: &str =
+    "https://api-c.liepin.com/api/com.liepin.usercx.pc.user.base-property";

--- a/src-tauri/src/rpa/run_flow.rs
+++ b/src-tauri/src/rpa/run_flow.rs
@@ -219,14 +219,26 @@ pub fn inspect_readiness(
     });
 
     let needs_reply_config = matches!(mode, FlowMode::ReplyUnread);
+    let replay_configs = config
+        .job_profiles
+        .iter()
+        .map(|profile| &profile.replay_config)
+        .collect::<Vec<_>>();
+    let auto_reply_configs = replay_configs
+        .iter()
+        .copied()
+        .filter(|replay| replay.enable_auto_replay)
+        .collect::<Vec<_>>();
+    let any_auto_reply = !auto_reply_configs.is_empty();
     let reply_ready = !needs_reply_config
-        || !config.replay_config.enable_auto_replay
-        || config.replay_config.enable_llm
-        || config.replay_config.templates.iter().any(|template| {
-            template
-                .content
-                .iter()
-                .any(|resource| !resource.content.trim().is_empty())
+        || auto_reply_configs.iter().all(|replay| {
+            replay.enable_llm
+                || replay.templates.iter().any(|template| {
+                    template
+                        .content
+                        .iter()
+                        .any(|resource| !resource.content.trim().is_empty())
+                })
         });
     items.push(ReadinessItem {
         key: "reply".to_string(),
@@ -238,8 +250,8 @@ pub fn inspect_readiness(
         },
         message: if !needs_reply_config {
             "当前模式不使用自动回复".to_string()
-        } else if !config.replay_config.enable_auto_replay {
-            "自动回复未启用".to_string()
+        } else if !any_auto_reply {
+            "所有求职方案均未启用自动回复".to_string()
         } else if reply_ready {
             "自动回复资源已配置".to_string()
         } else {
@@ -275,10 +287,14 @@ pub fn inspect_readiness(
         config_group: Some("job".to_string()),
     });
 
-    let llm_needed = !matches!(mode, FlowMode::SyncChatHistory)
-        && (config.replay_config.enable_llm
-            || config.job_filter_config.enable_semantic_filter
-            || config.greet_config.llm_resource_ready());
+    let llm_needed = match mode {
+        FlowMode::ReplyUnread => auto_reply_configs.iter().any(|replay| replay.enable_llm),
+        FlowMode::JobHunting | FlowMode::PeriodicJobHunting => {
+            config.job_filter_config.enable_semantic_filter
+                || config.greet_config.llm_resource_ready()
+        }
+        FlowMode::SyncChatHistory => false,
+    };
     items.push(ReadinessItem {
         key: "llm".to_string(),
         label: "大模型".to_string(),
@@ -390,6 +406,16 @@ impl Drop for JobTaskContextGuard {
 pub fn enter_job_task_context(task_id: String, cancelled: Arc<AtomicBool>) -> JobTaskContextGuard {
     CURRENT_JOB_TASK.with(|current| *current.borrow_mut() = Some((task_id, cancelled)));
     JobTaskContextGuard
+}
+
+/// 当前队列 worker 的任务标识。非队列兼容入口返回 None。
+pub fn current_job_task_id() -> Option<String> {
+    CURRENT_JOB_TASK.with(|current| {
+        current
+            .borrow()
+            .as_ref()
+            .map(|(task_id, _)| task_id.clone())
+    })
 }
 
 fn has_managed_job_task_context() -> bool {
@@ -768,6 +794,38 @@ mod tests {
 
         assert_eq!(llm.level, ReadinessLevel::Ready);
         assert_eq!(llm.message, "当前模式不依赖大模型");
+    }
+
+    #[test]
+    fn reply_readiness_checks_all_profile_routes_instead_of_only_default() {
+        let mut config = default_app_config();
+        config.job_profiles[0].replay_config.enable_auto_replay = false;
+        let mut routed = config.job_profiles[0].clone();
+        routed.id = "routed".to_string();
+        routed.name = "需要 AI 的历史方案".to_string();
+        routed.replay_config.enable_auto_replay = true;
+        routed.replay_config.enable_llm = true;
+        config.job_profiles.push(routed);
+
+        let report = inspect_readiness(PlatformKind::Boss, FlowMode::ReplyUnread, &config);
+
+        assert_eq!(find_item(&report, "reply").level, ReadinessLevel::Ready);
+        assert_eq!(find_item(&report, "llm").level, ReadinessLevel::Blocked);
+    }
+
+    #[test]
+    fn reply_readiness_allows_a_sync_run_when_every_profile_disables_auto_reply() {
+        let mut config = default_app_config();
+        config.job_profiles[0].replay_config.enable_auto_replay = false;
+
+        let report = inspect_readiness(PlatformKind::Boss, FlowMode::ReplyUnread, &config);
+
+        assert_eq!(find_item(&report, "reply").level, ReadinessLevel::Ready);
+        assert_eq!(
+            find_item(&report, "reply").message,
+            "所有求职方案均未启用自动回复"
+        );
+        assert_eq!(find_item(&report, "llm").level, ReadinessLevel::Ready);
     }
 
     #[test]

--- a/src-tauri/src/rpa/run_flow.rs
+++ b/src-tauri/src/rpa/run_flow.rs
@@ -1,8 +1,11 @@
 use std::{
+    cell::RefCell,
     sync::atomic::{AtomicBool, Ordering},
+    sync::Arc,
     time::Duration,
 };
 
+use rust_drission::{ChromiumPage, Page};
 use serde::{Deserialize, Serialize};
 
 use super::{boss, liepin};
@@ -10,6 +13,12 @@ use crate::{config::AppRuntimeConfig, logger};
 
 static JOB_TASK_RUNNING: AtomicBool = AtomicBool::new(false);
 static JOB_TASK_STOP_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+thread_local! {
+    /// Cancellation is scoped to the dedicated worker thread. Existing handler call sites can
+    /// keep using `is_job_task_stop_requested` without sharing a process-wide stop flag.
+    static CURRENT_JOB_TASK: RefCell<Option<(String, Arc<AtomicBool>)>> = const { RefCell::new(None) };
+}
 
 // --- Types ---
 
@@ -65,7 +74,7 @@ impl EnvCheckResult {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum PlatformKind {
     Boss,
@@ -356,7 +365,35 @@ pub fn stop_job_task() -> Result<(), String> {
 }
 
 pub fn is_job_task_stop_requested() -> bool {
-    JOB_TASK_STOP_REQUESTED.load(Ordering::SeqCst)
+    CURRENT_JOB_TASK
+        .with(|current| {
+            current
+                .borrow()
+                .as_ref()
+                .map(|(_, cancelled)| cancelled.load(Ordering::SeqCst))
+        })
+        .unwrap_or_else(|| JOB_TASK_STOP_REQUESTED.load(Ordering::SeqCst))
+}
+
+/// Installs the cancellation state for one dedicated task worker.
+///
+/// The guard deliberately is not `Send`: it must be dropped on the worker thread that installed
+/// it, at which point the thread-local context is cleared.
+pub struct JobTaskContextGuard;
+
+impl Drop for JobTaskContextGuard {
+    fn drop(&mut self) {
+        CURRENT_JOB_TASK.with(|current| *current.borrow_mut() = None);
+    }
+}
+
+pub fn enter_job_task_context(task_id: String, cancelled: Arc<AtomicBool>) -> JobTaskContextGuard {
+    CURRENT_JOB_TASK.with(|current| *current.borrow_mut() = Some((task_id, cancelled)));
+    JobTaskContextGuard
+}
+
+fn has_managed_job_task_context() -> bool {
+    CURRENT_JOB_TASK.with(|current| current.borrow().is_some())
 }
 
 pub fn try_start_job_task() -> Result<JobTaskRunningGuard, String> {
@@ -402,6 +439,24 @@ pub async fn execute_rpa_flow(
     interval_minutes: Option<u64>,
     config: &AppRuntimeConfig,
 ) -> Result<(), anyhow::Error> {
+    if has_managed_job_task_context() {
+        let config = config.clone();
+        return crate::browser::with_task_browser(|connection, main_tab| {
+            Box::pin(async move {
+                execute_rpa_flow_with_browser(
+                    connection,
+                    main_tab,
+                    platform,
+                    mode,
+                    interval_minutes,
+                    &config,
+                )
+                .await
+            })
+        })
+        .await;
+    }
+
     match mode {
         FlowMode::JobHunting => execute_job_hunting(platform, config).await,
         FlowMode::ReplyUnread => {
@@ -419,6 +474,36 @@ pub async fn execute_rpa_flow(
             let interval = resolve_periodic_interval_minutes(interval_minutes)
                 .map_err(|e| anyhow::anyhow!(e))?;
             periodic_position_say_hello(platform, config, interval).await
+        }
+    }
+}
+
+/// Execute a queued task on its independent CDP connection and owned main tab.
+pub async fn execute_rpa_flow_with_browser(
+    connection: &ChromiumPage,
+    main_tab: &Page,
+    platform: PlatformKind,
+    mode: FlowMode,
+    interval_minutes: Option<u64>,
+    config: &AppRuntimeConfig,
+) -> Result<(), anyhow::Error> {
+    match mode {
+        FlowMode::JobHunting => {
+            execute_job_hunting_on_page(connection, main_tab, platform, config).await
+        }
+        FlowMode::ReplyUnread => execute_reply_unread_on_page(main_tab, platform, config).await,
+        FlowMode::SyncChatHistory => {
+            if platform != PlatformKind::Boss {
+                return Err(anyhow::anyhow!("读取聊天消息任务目前仅支持 BOSS 直聘"));
+            }
+            boss::handler::sync_chat_history_on_page(main_tab).await?;
+            Ok(())
+        }
+        FlowMode::PeriodicJobHunting => {
+            let interval = resolve_periodic_interval_minutes(interval_minutes)
+                .map_err(|e| anyhow::anyhow!(e))?;
+            periodic_position_say_hello_on_page(connection, main_tab, platform, config, interval)
+                .await
         }
     }
 }
@@ -457,6 +542,38 @@ async fn execute_reply_unread(
     }
 }
 
+async fn execute_job_hunting_on_page(
+    connection: &ChromiumPage,
+    main_tab: &Page,
+    platform: PlatformKind,
+    config: &AppRuntimeConfig,
+) -> Result<(), anyhow::Error> {
+    match platform {
+        PlatformKind::Boss => {
+            boss::handler::position_say_hello_on_page(connection, main_tab, config).await
+        }
+        PlatformKind::Liepin => {
+            liepin::handler::position_say_hello_on_page(connection, main_tab, config).await
+        }
+    }
+}
+
+async fn execute_reply_unread_on_page(
+    main_tab: &Page,
+    platform: PlatformKind,
+    config: &AppRuntimeConfig,
+) -> Result<(), anyhow::Error> {
+    match platform {
+        PlatformKind::Boss => {
+            boss::handler::reply_unread_on_page(main_tab, config).await?;
+        }
+        PlatformKind::Liepin => {
+            liepin::handler::reply_unread_on_page(main_tab, config).await?;
+        }
+    }
+    Ok(())
+}
+
 fn resolve_periodic_interval_minutes(interval_minutes: Option<u64>) -> Result<u64, String> {
     match interval_minutes {
         Some(value) if value > 0 => Ok(value),
@@ -487,6 +604,39 @@ async fn periodic_position_say_hello(
         logger::info(format!("本轮投递完成，等待{}分钟后继续", interval_minutes))?;
         if platform == PlatformKind::Boss {
             if let Err(error) = boss::handler::sync_chat_history().await {
+                logger::warning(format!(
+                    "周期间歇同步 BOSS 历史对话失败，本轮继续等待: {error}"
+                ))?;
+            }
+        }
+        wait_periodic_interval(interval_minutes).await?;
+    }
+}
+
+async fn periodic_position_say_hello_on_page(
+    connection: &ChromiumPage,
+    main_tab: &Page,
+    platform: PlatformKind,
+    config: &AppRuntimeConfig,
+    interval_minutes: u64,
+) -> Result<(), anyhow::Error> {
+    loop {
+        if is_job_task_stop_requested() {
+            logger::info("周期性投递任务已结束")?;
+            return Ok(());
+        }
+
+        logger::info("开始执行本轮周期性投递")?;
+        execute_job_hunting_on_page(connection, main_tab, platform, config).await?;
+
+        if is_job_task_stop_requested() {
+            logger::info("周期性投递任务已结束")?;
+            return Ok(());
+        }
+
+        logger::info(format!("本轮投递完成，等待{}分钟后继续", interval_minutes))?;
+        if platform == PlatformKind::Boss {
+            if let Err(error) = boss::handler::sync_chat_history_on_page(main_tab).await {
                 logger::warning(format!(
                     "周期间歇同步 BOSS 历史对话失败，本轮继续等待: {error}"
                 ))?;

--- a/src-tauri/src/task/mod.rs
+++ b/src-tauri/src/task/mod.rs
@@ -55,6 +55,12 @@ pub struct JobTaskInfo {
     pub started_at: Option<String>,
     pub finished_at: Option<String>,
     pub error: Option<String>,
+    #[serde(default)]
+    pub profile_id: Option<String>,
+    #[serde(default)]
+    pub profile_name: Option<String>,
+    #[serde(default)]
+    pub profile_snapshot_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -97,6 +103,7 @@ impl SchedulerState {
         mode: FlowMode,
         interval_minutes: Option<u64>,
         config: Arc<AppRuntimeConfig>,
+        profile: Option<JobTaskProfile>,
     ) -> Result<JobTaskInfo, String> {
         if self.queue.len() >= MAX_QUEUED_TASKS {
             return Err(format!(
@@ -125,6 +132,11 @@ impl SchedulerState {
             started_at: None,
             finished_at: None,
             error: None,
+            profile_id: profile.as_ref().and_then(|value| value.profile_id.clone()),
+            profile_name: profile
+                .as_ref()
+                .and_then(|value| value.profile_name.clone()),
+            profile_snapshot_id: profile.and_then(|value| value.profile_snapshot_id),
         };
         self.tasks.insert(
             task_id.clone(),
@@ -305,11 +317,12 @@ impl TaskManager {
         mode: FlowMode,
         interval_minutes: Option<u64>,
         config: AppRuntimeConfig,
+        profile: Option<JobTaskProfile>,
     ) -> Result<JobTaskInfo, String> {
         let max_parallel_tasks = config.browser_config.max_parallel_tasks;
         let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
         state.max_parallel_tasks = normalize_parallelism(max_parallel_tasks);
-        let info = state.enqueue(platform, mode, interval_minutes, Arc::new(config))?;
+        let info = state.enqueue(platform, mode, interval_minutes, Arc::new(config), profile)?;
         self.inner.wake_scheduler.notify_one();
         Ok(info)
     }
@@ -332,6 +345,13 @@ impl TaskManager {
         self.inner.wake_scheduler.notify_one();
         result
     }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct JobTaskProfile {
+    pub profile_id: Option<String>,
+    pub profile_name: Option<String>,
+    pub profile_snapshot_id: Option<String>,
 }
 
 pub static JOB_TASK_MANAGER: Lazy<TaskManager> = Lazy::new(TaskManager::new);
@@ -417,6 +437,7 @@ mod tests {
                 FlowMode::JobHunting,
                 None,
                 Arc::new(default_app_config()),
+                None,
             )
             .unwrap()
     }
@@ -500,6 +521,7 @@ mod tests {
                 FlowMode::PeriodicJobHunting,
                 Some(30),
                 Arc::new(default_app_config()),
+                None,
             )
             .unwrap();
 
@@ -509,9 +531,32 @@ mod tests {
                 FlowMode::PeriodicJobHunting,
                 Some(60),
                 Arc::new(default_app_config()),
+                None,
             )
             .unwrap_err();
 
         assert!(error.contains("已有周期投递任务"));
+    }
+
+    #[test]
+    fn task_info_exposes_bound_profile_metadata() {
+        let mut state = SchedulerState::new(1);
+        let info = state
+            .enqueue(
+                PlatformKind::Boss,
+                FlowMode::JobHunting,
+                None,
+                Arc::new(default_app_config()),
+                Some(JobTaskProfile {
+                    profile_id: Some("rust".into()),
+                    profile_name: Some("Rust 后端".into()),
+                    profile_snapshot_id: Some("fnv-1".into()),
+                }),
+            )
+            .unwrap();
+
+        assert_eq!(info.profile_id.as_deref(), Some("rust"));
+        assert_eq!(info.profile_name.as_deref(), Some("Rust 后端"));
+        assert_eq!(info.profile_snapshot_id.as_deref(), Some("fnv-1"));
     }
 }

--- a/src-tauri/src/task/mod.rs
+++ b/src-tauri/src/task/mod.rs
@@ -1,0 +1,517 @@
+//! Bounded background job queue and scheduler.
+//!
+//! Browser automation itself remains synchronous from the scheduler's point of view: every
+//! dispatched job owns a dedicated OS thread and a current-thread Tokio runtime.  Keeping the
+//! scheduling state here makes job cancellation and platform-level exclusion independent from
+//! the browser implementation.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Condvar, Mutex,
+    },
+    thread,
+};
+
+use chrono::{SecondsFormat, Utc};
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    config::AppRuntimeConfig,
+    rpa::run_flow::{self, FlowMode, PlatformKind},
+};
+
+const MAX_QUEUED_TASKS: usize = 32;
+const FINISHED_TASK_HISTORY_LIMIT: usize = 100;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum JobTaskState {
+    Queued,
+    Starting,
+    Running,
+    Stopping,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl JobTaskState {
+    fn is_terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct JobTaskInfo {
+    pub task_id: String,
+    pub platform: PlatformKind,
+    pub mode: FlowMode,
+    pub status: JobTaskState,
+    pub created_at: String,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct JobTaskOverview {
+    pub tasks: Vec<JobTaskInfo>,
+    pub running_count: usize,
+    pub queued_count: usize,
+    pub max_parallel_tasks: usize,
+}
+
+struct TaskEntry {
+    info: JobTaskInfo,
+    interval_minutes: Option<u64>,
+    config: Arc<AppRuntimeConfig>,
+    cancelled: Arc<AtomicBool>,
+}
+
+struct SchedulerState {
+    tasks: HashMap<String, TaskEntry>,
+    queue: VecDeque<String>,
+    running_by_platform: HashMap<PlatformKind, String>,
+    running_count: usize,
+    max_parallel_tasks: usize,
+}
+
+impl SchedulerState {
+    fn new(max_parallel_tasks: usize) -> Self {
+        Self {
+            tasks: HashMap::new(),
+            queue: VecDeque::new(),
+            running_by_platform: HashMap::new(),
+            running_count: 0,
+            max_parallel_tasks: normalize_parallelism(max_parallel_tasks),
+        }
+    }
+
+    fn enqueue(
+        &mut self,
+        platform: PlatformKind,
+        mode: FlowMode,
+        interval_minutes: Option<u64>,
+        config: Arc<AppRuntimeConfig>,
+    ) -> Result<JobTaskInfo, String> {
+        if self.queue.len() >= MAX_QUEUED_TASKS {
+            return Err(format!(
+                "任务队列已满（最多等待 {MAX_QUEUED_TASKS} 个任务）"
+            ));
+        }
+
+        if mode == FlowMode::PeriodicJobHunting
+            && self.tasks.values().any(|entry| {
+                entry.info.platform == platform
+                    && entry.info.mode == FlowMode::PeriodicJobHunting
+                    && !entry.info.status.is_terminal()
+            })
+        {
+            return Err("该平台已有周期投递任务，请先停止后再重新启动".to_string());
+        }
+
+        let now = timestamp();
+        let task_id = Uuid::new_v4().to_string();
+        let info = JobTaskInfo {
+            task_id: task_id.clone(),
+            platform,
+            mode,
+            status: JobTaskState::Queued,
+            created_at: now,
+            started_at: None,
+            finished_at: None,
+            error: None,
+        };
+        self.tasks.insert(
+            task_id.clone(),
+            TaskEntry {
+                info: info.clone(),
+                interval_minutes,
+                config,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            },
+        );
+        self.queue.push_back(task_id);
+        Ok(info)
+    }
+
+    /// Takes the oldest task whose platform is currently available.
+    ///
+    /// This preserves FIFO order for every platform while allowing a Liepin task to pass a
+    /// waiting Boss task when Boss already has a worker (and vice versa).
+    fn take_next_runnable(&mut self) -> Option<WorkerInput> {
+        if self.running_count >= self.max_parallel_tasks {
+            return None;
+        }
+
+        let queue_index = self.queue.iter().position(|task_id| {
+            self.tasks
+                .get(task_id)
+                .is_some_and(|entry| !self.running_by_platform.contains_key(&entry.info.platform))
+        })?;
+        let task_id = self.queue.remove(queue_index)?;
+        let entry = self.tasks.get_mut(&task_id)?;
+        entry.info.status = JobTaskState::Starting;
+        entry.info.started_at = Some(timestamp());
+        self.running_count += 1;
+        self.running_by_platform
+            .insert(entry.info.platform, task_id.clone());
+
+        Some(WorkerInput {
+            task_id,
+            platform: entry.info.platform,
+            mode: entry.info.mode,
+            interval_minutes: entry.interval_minutes,
+            config: Arc::clone(&entry.config),
+            cancelled: Arc::clone(&entry.cancelled),
+        })
+    }
+
+    fn request_stop(&mut self, task_id: &str) -> Result<(), String> {
+        let entry = self
+            .tasks
+            .get_mut(task_id)
+            .ok_or_else(|| "求职任务不存在".to_string())?;
+        match entry.info.status {
+            JobTaskState::Queued => {
+                entry.cancelled.store(true, Ordering::SeqCst);
+                entry.info.status = JobTaskState::Cancelled;
+                entry.info.finished_at = Some(timestamp());
+                self.queue.retain(|queued_id| queued_id != task_id);
+            }
+            JobTaskState::Starting | JobTaskState::Running => {
+                entry.cancelled.store(true, Ordering::SeqCst);
+                entry.info.status = JobTaskState::Stopping;
+            }
+            JobTaskState::Stopping => {}
+            status if status.is_terminal() => return Err("求职任务已结束".to_string()),
+            _ => unreachable!("all task states are covered"),
+        }
+        Ok(())
+    }
+
+    fn mark_running(&mut self, task_id: &str) {
+        if let Some(entry) = self.tasks.get_mut(task_id) {
+            if entry.cancelled.load(Ordering::SeqCst) {
+                entry.info.status = JobTaskState::Stopping;
+            } else {
+                entry.info.status = JobTaskState::Running;
+            }
+        }
+    }
+
+    fn finish(&mut self, task_id: &str, result: Result<(), anyhow::Error>) {
+        let Some(entry) = self.tasks.get_mut(task_id) else {
+            return;
+        };
+        let platform = entry.info.platform;
+        let cancelled = entry.cancelled.load(Ordering::SeqCst);
+        entry.info.finished_at = Some(timestamp());
+        match (cancelled, result) {
+            (true, _) => {
+                entry.info.status = JobTaskState::Cancelled;
+                entry.info.error = None;
+            }
+            (false, Ok(())) => entry.info.status = JobTaskState::Succeeded,
+            (false, Err(error)) => {
+                entry.info.status = JobTaskState::Failed;
+                entry.info.error = Some(error.to_string());
+            }
+        }
+        self.running_count = self.running_count.saturating_sub(1);
+        if self
+            .running_by_platform
+            .get(&platform)
+            .is_some_and(|running_id| running_id == task_id)
+        {
+            self.running_by_platform.remove(&platform);
+        }
+        self.trim_finished_history();
+    }
+
+    fn overview(&self) -> JobTaskOverview {
+        let mut tasks = self
+            .tasks
+            .values()
+            .map(|entry| entry.info.clone())
+            .collect::<Vec<_>>();
+        tasks.sort_by(|left, right| {
+            right
+                .created_at
+                .cmp(&left.created_at)
+                .then_with(|| right.task_id.cmp(&left.task_id))
+        });
+        JobTaskOverview {
+            tasks,
+            running_count: self.running_count,
+            queued_count: self.queue.len(),
+            max_parallel_tasks: self.max_parallel_tasks,
+        }
+    }
+
+    fn trim_finished_history(&mut self) {
+        let mut finished = self
+            .tasks
+            .iter()
+            .filter(|(_, entry)| entry.info.status.is_terminal())
+            .map(|(task_id, entry)| (task_id.clone(), entry.info.finished_at.clone()))
+            .collect::<Vec<_>>();
+        if finished.len() <= FINISHED_TASK_HISTORY_LIMIT {
+            return;
+        }
+        finished.sort_by(|left, right| left.1.cmp(&right.1));
+        let remove_count = finished.len() - FINISHED_TASK_HISTORY_LIMIT;
+        for (task_id, _) in finished.into_iter().take(remove_count) {
+            self.tasks.remove(&task_id);
+        }
+    }
+}
+
+struct WorkerInput {
+    task_id: String,
+    platform: PlatformKind,
+    mode: FlowMode,
+    interval_minutes: Option<u64>,
+    config: Arc<AppRuntimeConfig>,
+    cancelled: Arc<AtomicBool>,
+}
+
+struct TaskManagerInner {
+    state: Mutex<SchedulerState>,
+    wake_scheduler: Condvar,
+}
+
+pub struct TaskManager {
+    inner: Arc<TaskManagerInner>,
+}
+
+impl TaskManager {
+    fn new() -> Self {
+        let inner = Arc::new(TaskManagerInner {
+            state: Mutex::new(SchedulerState::new(2)),
+            wake_scheduler: Condvar::new(),
+        });
+        spawn_scheduler(Arc::clone(&inner));
+        Self { inner }
+    }
+
+    pub fn submit(
+        &self,
+        platform: PlatformKind,
+        mode: FlowMode,
+        interval_minutes: Option<u64>,
+        config: AppRuntimeConfig,
+    ) -> Result<JobTaskInfo, String> {
+        let max_parallel_tasks = config.browser_config.max_parallel_tasks;
+        let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.max_parallel_tasks = normalize_parallelism(max_parallel_tasks);
+        let info = state.enqueue(platform, mode, interval_minutes, Arc::new(config))?;
+        self.inner.wake_scheduler.notify_one();
+        Ok(info)
+    }
+
+    pub fn overview(&self) -> JobTaskOverview {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .overview()
+    }
+
+    pub fn stop(&self, task_id: &str) -> Result<(), String> {
+        let result = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .request_stop(task_id);
+        self.inner.wake_scheduler.notify_one();
+        result
+    }
+}
+
+pub static JOB_TASK_MANAGER: Lazy<TaskManager> = Lazy::new(TaskManager::new);
+
+fn spawn_scheduler(inner: Arc<TaskManagerInner>) {
+    thread::Builder::new()
+        .name("job-task-scheduler".to_string())
+        .spawn(move || loop {
+            let worker = {
+                let mut state = inner.state.lock().unwrap_or_else(|e| e.into_inner());
+                loop {
+                    if let Some(worker) = state.take_next_runnable() {
+                        break worker;
+                    }
+                    state = inner
+                        .wake_scheduler
+                        .wait(state)
+                        .unwrap_or_else(|e| e.into_inner());
+                }
+            };
+            spawn_worker(Arc::clone(&inner), worker);
+        })
+        .expect("failed to start job task scheduler");
+}
+
+fn spawn_worker(inner: Arc<TaskManagerInner>, worker: WorkerInput) {
+    let thread_name = format!("job-task-{}", &worker.task_id[..8]);
+    thread::Builder::new()
+        .name(thread_name)
+        .spawn(move || {
+            let _log_context =
+                crate::logger::scoped_context(Some(worker.task_id.clone()), Some(worker.platform));
+            {
+                let mut state = inner.state.lock().unwrap_or_else(|e| e.into_inner());
+                state.mark_running(&worker.task_id);
+            }
+
+            let _task_context = run_flow::enter_job_task_context(
+                worker.task_id.clone(),
+                Arc::clone(&worker.cancelled),
+            );
+            let result = if worker.cancelled.load(Ordering::SeqCst) {
+                Ok(())
+            } else {
+                match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime.block_on(run_flow::execute_rpa_flow(
+                        worker.platform,
+                        worker.mode,
+                        worker.interval_minutes,
+                        &worker.config,
+                    )),
+                    Err(error) => Err(anyhow::anyhow!("创建任务运行时失败: {error}")),
+                }
+            };
+
+            let mut state = inner.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.finish(&worker.task_id, result);
+            inner.wake_scheduler.notify_one();
+        })
+        .expect("failed to start job task worker");
+}
+
+fn normalize_parallelism(value: usize) -> usize {
+    value.clamp(1, 2)
+}
+
+fn timestamp() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::default_app_config;
+
+    fn enqueue(state: &mut SchedulerState, platform: PlatformKind) -> JobTaskInfo {
+        state
+            .enqueue(
+                platform,
+                FlowMode::JobHunting,
+                None,
+                Arc::new(default_app_config()),
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn scheduler_runs_different_platforms_in_parallel_and_queues_same_platform() {
+        let mut state = SchedulerState::new(2);
+        let boss_first = enqueue(&mut state, PlatformKind::Boss);
+        let boss_second = enqueue(&mut state, PlatformKind::Boss);
+        let liepin = enqueue(&mut state, PlatformKind::Liepin);
+
+        assert_eq!(
+            state.take_next_runnable().unwrap().task_id,
+            boss_first.task_id
+        );
+        assert_eq!(state.take_next_runnable().unwrap().task_id, liepin.task_id);
+        assert!(state.take_next_runnable().is_none());
+        assert_eq!(state.queue.front(), Some(&boss_second.task_id));
+    }
+
+    #[test]
+    fn same_platform_tasks_keep_fifo_order() {
+        let mut state = SchedulerState::new(2);
+        let _first = enqueue(&mut state, PlatformKind::Boss);
+        let second = enqueue(&mut state, PlatformKind::Boss);
+        let first_worker = state.take_next_runnable().unwrap();
+        state.finish(&first_worker.task_id, Ok(()));
+
+        assert_eq!(state.take_next_runnable().unwrap().task_id, second.task_id);
+    }
+
+    #[test]
+    fn cancelling_one_task_does_not_cancel_another() {
+        let mut state = SchedulerState::new(2);
+        let boss = enqueue(&mut state, PlatformKind::Boss);
+        let liepin = enqueue(&mut state, PlatformKind::Liepin);
+        let boss_worker = state.take_next_runnable().unwrap();
+        let liepin_worker = state.take_next_runnable().unwrap();
+
+        state.request_stop(&boss.task_id).unwrap();
+
+        assert!(boss_worker.cancelled.load(Ordering::SeqCst));
+        assert!(!liepin_worker.cancelled.load(Ordering::SeqCst));
+        assert_eq!(
+            state.tasks[&boss.task_id].info.status,
+            JobTaskState::Stopping
+        );
+        assert_eq!(
+            state.tasks[&liepin.task_id].info.status,
+            JobTaskState::Starting
+        );
+    }
+
+    #[test]
+    fn cancelling_queued_task_removes_it_from_queue() {
+        let mut state = SchedulerState::new(1);
+        let first = enqueue(&mut state, PlatformKind::Boss);
+        let queued = enqueue(&mut state, PlatformKind::Liepin);
+        let _ = state.take_next_runnable().unwrap();
+
+        state.request_stop(&queued.task_id).unwrap();
+
+        assert!(state.queue.is_empty());
+        assert_eq!(
+            state.tasks[&queued.task_id].info.status,
+            JobTaskState::Cancelled
+        );
+        assert_eq!(state.running_count, 1);
+        assert_eq!(
+            state.tasks[&first.task_id].info.status,
+            JobTaskState::Starting
+        );
+    }
+
+    #[test]
+    fn duplicate_periodic_task_for_the_same_platform_is_rejected() {
+        let mut state = SchedulerState::new(2);
+        state
+            .enqueue(
+                PlatformKind::Boss,
+                FlowMode::PeriodicJobHunting,
+                Some(30),
+                Arc::new(default_app_config()),
+            )
+            .unwrap();
+
+        let error = state
+            .enqueue(
+                PlatformKind::Boss,
+                FlowMode::PeriodicJobHunting,
+                Some(60),
+                Arc::new(default_app_config()),
+            )
+            .unwrap_err();
+
+        assert!(error.contains("已有周期投递任务"));
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Alert, Button, ConfigProvider, Spin, Tabs, Typography } from "antd";
 import { RocketOutlined } from "@ant-design/icons";
 import "./App.css";
 import { useAppConfig } from "@/hooks/useAppConfig";
-import type { AppRuntimeConfig, BrowserConfig, GreetConfig, GreetResource, JobFilterConfig, RegexRule, ReplayConfig, ReplyResource, ReplyTemplate, ResumeConfig } from "@/types/app-config";
+import { copyJobProfile, getDefaultJobProfile, getJobProfiles, selectProfileAfterRemoval, type AppRuntimeConfig, type BrowserConfig, type GreetConfig, type GreetResource, type JobFilterConfig, type JobProfile, type RegexRule, type ReplayConfig, type ReplyResource, type ReplyTemplate, type ResumeConfig } from "@/types/app-config";
 import { Onboarding } from "@/view/onboarding";
 import { ConfigPage } from "@/view/config";
 import ConversationDebugPage from "@/view/conversation-debug";
@@ -37,6 +37,20 @@ function MainShell({ config, update, save, status, message, dirty, importConfig,
 }) {
   const [activeTab, setActiveTab] = useState<AppTabKey>("workspace");
   const [configGroup, setConfigGroup] = useState<"resume" | "llm" | "job" | "greet" | "reply" | "browser">("resume");
+  const [activeProfileId, setActiveProfileId] = useState(() => getDefaultJobProfile(config).id);
+  const profiles = getJobProfiles(config);
+  const activeProfile = profiles.find((profile) => profile.id === activeProfileId)
+    ?? getDefaultJobProfile(config);
+  const profileConfig = useMemo(() => ({
+    ...config,
+    job_profiles: profiles,
+    default_job_profile_id: config.default_job_profile_id || getDefaultJobProfile(config).id,
+    job_filter_config: activeProfile.job_filter_config,
+    platform_filter_config: activeProfile.platform_filter_config,
+    resume_config: activeProfile.resume_config,
+    greet_config: activeProfile.greet_config,
+    replay_config: activeProfile.replay_config,
+  }), [activeProfile, config, profiles]);
   useEffect(() => {
     if (!dirty || status === "loading" || status === "error") return;
     const timer = window.setTimeout(() => { void save(); }, 700);
@@ -47,34 +61,74 @@ function MainShell({ config, update, save, status, message, dirty, importConfig,
   const openConfig = (group: typeof configGroup) => { setConfigGroup(group); setActiveTab("config"); };
   const openLlm = () => openConfig("llm");
   const merge = <K extends keyof AppRuntimeConfig>(key: K, next: Partial<AppRuntimeConfig[K]>) => update((c) => ({ ...c, [key]: { ...(c[key] as object), ...next } }));
-  const configPage = <ConfigPage config={config} status={status} message={message} dirty={dirty} initialGroup={configGroup}
+  const updateActiveProfile = (mutate: (profile: JobProfile) => JobProfile) => update((c) => {
+    const currentProfiles = getJobProfiles(c);
+    const selected = currentProfiles.find((profile) => profile.id === activeProfileId)
+      ?? getDefaultJobProfile(c);
+    const nextProfiles = currentProfiles.map((profile) => profile.id === selected.id ? mutate(profile) : profile);
+    return {
+      ...c,
+      job_profiles: nextProfiles,
+      default_job_profile_id: c.default_job_profile_id || selected.id,
+    };
+  });
+  const updateProfileSection = <K extends "job_filter_config" | "greet_config" | "replay_config" | "resume_config">(key: K, next: Partial<JobProfile[K]>) =>
+    updateActiveProfile((profile) => ({ ...profile, [key]: { ...profile[key], ...next } }));
+  const updateProfiles = (nextProfiles: JobProfile[], defaultId = config.default_job_profile_id) => update((c) => ({
+    ...c,
+    job_profiles: nextProfiles,
+    default_job_profile_id: defaultId || nextProfiles[0]?.id || "default",
+  }));
+  const createProfile = (source: JobProfile, suffix = "新方案", meta?: Pick<JobProfile, "name" | "description">) => {
+    const id = globalThis.crypto?.randomUUID?.() ?? `profile-${Date.now()}`;
+    const copied = copyJobProfile(source, id, suffix);
+    const next = meta ? { ...copied, ...meta } : copied;
+    updateProfiles([...profiles, next]);
+    setActiveProfileId(id);
+  };
+  const configPage = <ConfigPage config={profileConfig} status={status} message={message} dirty={dirty} initialGroup={configGroup}
+    activeProfileId={activeProfile.id}
+    onSelectProfile={setActiveProfileId}
+    onCreateProfile={(meta) => createProfile(getDefaultJobProfile(config), "新方案", meta)}
+    onDuplicateProfile={() => createProfile(activeProfile, "副本")}
+    onUpdateProfileMeta={(next) => updateActiveProfile((profile) => ({ ...profile, ...next }))}
+    onSetDefaultProfile={() => updateProfiles(profiles, activeProfile.id)}
+    onArchiveProfile={() => {
+      updateProfiles(profiles.map((profile) => profile.id === activeProfile.id ? { ...profile, archived: true } : profile));
+      setActiveProfileId(selectProfileAfterRemoval(profiles, activeProfile.id)?.id ?? getDefaultJobProfile(config).id);
+    }}
+    onDeleteProfile={() => {
+      const next = profiles.filter((profile) => profile.id !== activeProfile.id);
+      updateProfiles(next);
+      setActiveProfileId(selectProfileAfterRemoval(profiles, activeProfile.id)?.id ?? "default");
+    }}
     onOpenLlmConfig={openLlm}
     updateLlm={(llm_config) => update((c) => ({ ...c, llm_config }))}
     persistLlm={async (llm_config) => save({ ...config, llm_config })}
     updateLlmFallbacks={(llm_fallbacks) => update((c) => ({ ...c, llm_fallbacks }))}
     updateLlmRetryConfig={(llm_retry_config) => update((c) => ({ ...c, llm_retry_config }))}
     persistConfig={() => save()}
-    updateJobFilter={(v: Partial<JobFilterConfig>) => merge("job_filter_config", v)}
-    updateGreet={(v: Partial<GreetConfig>) => merge("greet_config", v)}
-    updateGreetDefaultResource={(i: number, v: Partial<GreetResource>) => update((c) => ({ ...c, greet_config: { ...c.greet_config, default_template: updateAt(c.greet_config.default_template, i, v) } }))}
-    addGreetDefaultResource={(resourceType: GreetResource["resource_type"] = "Text") => update((c) => ({ ...c, greet_config: { ...c.greet_config, default_template: [...c.greet_config.default_template, { resource_type: resourceType, content: "" }] } }))}
-    moveGreetDefaultResource={(i: number, offset: -1 | 1) => update((c) => ({ ...c, greet_config: { ...c.greet_config, default_template: moveAt(c.greet_config.default_template, i, offset) } }))}
-    removeGreetDefaultResource={(i: number) => update((c) => ({ ...c, greet_config: { ...c.greet_config, default_template: c.greet_config.default_template.filter((_, x) => x !== i) } }))}
-    updateReplay={(v: Partial<ReplayConfig>) => merge("replay_config", v)}
-    updateReplyTemplate={(i: number, v: Partial<ReplyTemplate>) => update((c) => ({ ...c, replay_config: { ...c.replay_config, templates: updateAt(c.replay_config.templates, i, v) } }))}
-    addReplyTemplate={() => update((c) => ({ ...c, replay_config: { ...c.replay_config, templates: [...c.replay_config.templates, { regex_rule: { name: "", pattern: "", limit: 5 }, content: [{ resource_type: "Text", content: "" }] }] } }))}
-    removeReplyTemplate={(i: number) => update((c) => ({ ...c, replay_config: { ...c.replay_config, templates: c.replay_config.templates.filter((_, x) => x !== i) } }))}
-    updateReplyResource={(ti: number, ri: number, v: Partial<ReplyResource>) => update((c) => ({ ...c, replay_config: { ...c.replay_config, templates: c.replay_config.templates.map((t, i) => i === ti ? { ...t, content: updateAt(t.content, ri, v) } : t) } }))}
-    addReplyResource={(ti: number) => update((c) => ({ ...c, replay_config: { ...c.replay_config, templates: c.replay_config.templates.map((t, i) => i === ti ? { ...t, content: [...t.content, { resource_type: "Text", content: "" }] } : t) } }))}
-    removeReplyResource={(ti: number, ri: number) => update((c) => ({ ...c, replay_config: { ...c.replay_config, templates: c.replay_config.templates.map((t, i) => i === ti ? { ...t, content: t.content.filter((_, x) => x !== ri) } : t) } }))}
-    updateBrowser={(v: Partial<BrowserConfig>) => merge("browser_config", v)} updateResume={(v: Partial<ResumeConfig>) => merge("resume_config", v)}
-    updateRule={(i: number, v: Partial<RegexRule>) => update((c) => ({ ...c, job_filter_config: { ...c.job_filter_config, regex_rules: updateAt(c.job_filter_config.regex_rules, i, v) } }))}
-    addRule={() => update((c) => ({ ...c, job_filter_config: { ...c.job_filter_config, regex_rules: [...c.job_filter_config.regex_rules, { name: "", pattern: "", target: "All", mode: "ACCEPT" }] } }))}
-    addRules={(rules: RegexRule[]) => update((c) => ({ ...c, job_filter_config: { ...c.job_filter_config, regex_rules: [...c.job_filter_config.regex_rules, ...rules] } }))}
-    removeRule={(i: number) => update((c) => ({ ...c, job_filter_config: { ...c.job_filter_config, regex_rules: c.job_filter_config.regex_rules.filter((_, x) => x !== i) } }))}
+    updateJobFilter={(v: Partial<JobFilterConfig>) => updateProfileSection("job_filter_config", v)}
+    updateGreet={(v: Partial<GreetConfig>) => updateProfileSection("greet_config", v)}
+    updateGreetDefaultResource={(i: number, v: Partial<GreetResource>) => updateActiveProfile((p) => ({ ...p, greet_config: { ...p.greet_config, default_template: updateAt(p.greet_config.default_template, i, v) } }))}
+    addGreetDefaultResource={(resourceType: GreetResource["resource_type"] = "Text") => updateActiveProfile((p) => ({ ...p, greet_config: { ...p.greet_config, default_template: [...p.greet_config.default_template, { resource_type: resourceType, content: "" }] } }))}
+    moveGreetDefaultResource={(i: number, offset: -1 | 1) => updateActiveProfile((p) => ({ ...p, greet_config: { ...p.greet_config, default_template: moveAt(p.greet_config.default_template, i, offset) } }))}
+    removeGreetDefaultResource={(i: number) => updateActiveProfile((p) => ({ ...p, greet_config: { ...p.greet_config, default_template: p.greet_config.default_template.filter((_, x) => x !== i) } }))}
+    updateReplay={(v: Partial<ReplayConfig>) => updateProfileSection("replay_config", v)}
+    updateReplyTemplate={(i: number, v: Partial<ReplyTemplate>) => updateActiveProfile((p) => ({ ...p, replay_config: { ...p.replay_config, templates: updateAt(p.replay_config.templates, i, v) } }))}
+    addReplyTemplate={() => updateActiveProfile((p) => ({ ...p, replay_config: { ...p.replay_config, templates: [...p.replay_config.templates, { regex_rule: { name: "", pattern: "", limit: 5 }, content: [{ resource_type: "Text", content: "" }] }] } }))}
+    removeReplyTemplate={(i: number) => updateActiveProfile((p) => ({ ...p, replay_config: { ...p.replay_config, templates: p.replay_config.templates.filter((_, x) => x !== i) } }))}
+    updateReplyResource={(ti: number, ri: number, v: Partial<ReplyResource>) => updateActiveProfile((p) => ({ ...p, replay_config: { ...p.replay_config, templates: p.replay_config.templates.map((t, i) => i === ti ? { ...t, content: updateAt(t.content, ri, v) } : t) } }))}
+    addReplyResource={(ti: number) => updateActiveProfile((p) => ({ ...p, replay_config: { ...p.replay_config, templates: p.replay_config.templates.map((t, i) => i === ti ? { ...t, content: [...t.content, { resource_type: "Text", content: "" }] } : t) } }))}
+    removeReplyResource={(ti: number, ri: number) => updateActiveProfile((p) => ({ ...p, replay_config: { ...p.replay_config, templates: p.replay_config.templates.map((t, i) => i === ti ? { ...t, content: t.content.filter((_, x) => x !== ri) } : t) } }))}
+    updateBrowser={(v: Partial<BrowserConfig>) => merge("browser_config", v)} updateResume={(v: Partial<ResumeConfig>) => updateProfileSection("resume_config", v)}
+    updateRule={(i: number, v: Partial<RegexRule>) => updateActiveProfile((p) => ({ ...p, job_filter_config: { ...p.job_filter_config, regex_rules: updateAt(p.job_filter_config.regex_rules, i, v) } }))}
+    addRule={() => updateActiveProfile((p) => ({ ...p, job_filter_config: { ...p.job_filter_config, regex_rules: [...p.job_filter_config.regex_rules, { name: "", pattern: "", target: "All", mode: "ACCEPT" }] } }))}
+    addRules={(rules: RegexRule[]) => updateActiveProfile((p) => ({ ...p, job_filter_config: { ...p.job_filter_config, regex_rules: [...p.job_filter_config.regex_rules, ...rules] } }))}
+    removeRule={(i: number) => updateActiveProfile((p) => ({ ...p, job_filter_config: { ...p.job_filter_config, regex_rules: p.job_filter_config.regex_rules.filter((_, x) => x !== i) } }))}
     importConfig={importConfig} exportConfig={exportConfig} />;
 
-  const content = activeTab === "workspace" ? <WorkspacePage onNavigate={(tab) => void navigate(tab)} onOpenConfig={openConfig} /> : activeTab === "job-overview" ? <JobOverviewPage /> : activeTab === "job-data" ? <JobDataPage aiConfigured={!!config.llm_config} onConfigureAi={openLlm} /> : activeTab === "conversation-debug" ? <ConversationDebugPage aiConfigured={!!config.llm_config} onConfigureAi={openLlm} /> : activeTab === "resume-optimizer" ? <ResumeOptimizerPage config={config} onOpenLlmConfig={openLlm} onUpdateResume={(resume_content) => merge("resume_config", { resume_content })} /> : configPage;
+  const content = activeTab === "workspace" ? <WorkspacePage config={config} onNavigate={(tab) => void navigate(tab)} onOpenConfig={openConfig} /> : activeTab === "job-overview" ? <JobOverviewPage /> : activeTab === "job-data" ? <JobDataPage aiConfigured={!!config.llm_config} onConfigureAi={openLlm} /> : activeTab === "conversation-debug" ? <ConversationDebugPage aiConfigured={!!config.llm_config} onConfigureAi={openLlm} /> : activeTab === "resume-optimizer" ? <ResumeOptimizerPage config={profileConfig} onOpenLlmConfig={openLlm} onUpdateResume={(resume_content) => updateProfileSection("resume_config", { resume_content })} /> : configPage;
   return (
     <main className="app-shell">
       <header className="app-header">

--- a/src/hooks/useAppConfig.test.tsx
+++ b/src/hooks/useAppConfig.test.tsx
@@ -22,7 +22,7 @@ const config: AppRuntimeConfig = {
   platform_filter_config: { liepin: { dq: null, salary_code: null, pub_time: null, work_year_code: null, comp_tag: [] } },
   greet_config: { enable_llm: false, reply_prompt: null, default_template: [] },
   replay_config: { enable_auto_replay: false, templates: [], enable_llm: false, reply_prompt: null, background_context: null },
-  browser_config: { user_data_dir: "profile", chrome_exe_path: null },
+  browser_config: { user_data_dir: "profile", chrome_exe_path: null, max_parallel_tasks: 2 },
   resume_config: { inject_llm_context: false, resume_path: null, resume_content: null },
 };
 

--- a/src/types/app-config.test.ts
+++ b/src/types/app-config.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { copyJobProfile, getDefaultJobProfile, getJobProfiles, selectProfileAfterRemoval, type AppRuntimeConfig } from "./app-config";
+
+const legacyConfig = {
+  default_job_profile_id: undefined,
+  job_filter_config: { query: "Rust" },
+  platform_filter_config: { liepin: {} },
+  resume_config: { resume_content: "resume" },
+  greet_config: { default_template: [] },
+  replay_config: { templates: [] },
+} as unknown as AppRuntimeConfig;
+
+describe("job profile compatibility", () => {
+  it("projects legacy top-level settings into one default profile", () => {
+    const profiles = getJobProfiles(legacyConfig);
+
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]).toMatchObject({
+      id: "default",
+      name: "默认求职方案",
+      archived: false,
+      job_filter_config: { query: "Rust" },
+      resume_config: { resume_content: "resume" },
+    });
+    expect(getDefaultJobProfile(legacyConfig)).toStrictEqual(profiles[0]);
+  });
+
+  it("prefers the configured default profile", () => {
+    const fallback = getJobProfiles(legacyConfig)[0];
+    const config = {
+      ...legacyConfig,
+      default_job_profile_id: "second",
+      job_profiles: [fallback, { ...fallback, id: "second", name: "第二方案" }],
+    };
+
+    expect(getDefaultJobProfile(config).name).toBe("第二方案");
+  });
+
+  it("does not select an archived configured default profile", () => {
+    const fallback = getJobProfiles(legacyConfig)[0];
+    const config = {
+      ...legacyConfig,
+      default_job_profile_id: "archived",
+      job_profiles: [{ ...fallback, id: "archived", archived: true }, { ...fallback, id: "active", name: "可用方案" }],
+    };
+
+    expect(getDefaultJobProfile(config).id).toBe("active");
+  });
+
+  it("copies strategy content under a fresh active identity", () => {
+    const source = getJobProfiles(legacyConfig)[0];
+    const copied = copyJobProfile({ ...source, archived: true }, "copy-id", "副本");
+
+    expect(copied).toMatchObject({ id: "copy-id", name: "默认求职方案 · 副本", archived: false });
+    expect(copied.job_filter_config).not.toBe(source.job_filter_config);
+  });
+
+  it("selects a non-archived profile after archive or deletion", () => {
+    const source = getJobProfiles(legacyConfig)[0];
+    const profiles = [
+      { ...source, id: "removed" },
+      { ...source, id: "archived", archived: true },
+      { ...source, id: "active" },
+    ];
+
+    expect(selectProfileAfterRemoval(profiles, "removed")?.id).toBe("active");
+    expect(selectProfileAfterRemoval([profiles[0]], "removed")).toBeNull();
+  });
+});

--- a/src/types/app-config.ts
+++ b/src/types/app-config.ts
@@ -144,6 +144,7 @@ export interface ReplayConfig {
 export interface BrowserConfig {
   user_data_dir: string;
   chrome_exe_path: string | null;
+  max_parallel_tasks: number;
 }
 
 export interface ResumeConfig {

--- a/src/types/app-config.ts
+++ b/src/types/app-config.ts
@@ -153,6 +153,19 @@ export interface ResumeConfig {
   resume_content: string | null;
 }
 
+/** 一套可独立执行的求职方向、简历与沟通策略。 */
+export interface JobProfile {
+  id: string;
+  name: string;
+  description?: string | null;
+  archived: boolean;
+  job_filter_config: JobFilterConfig;
+  platform_filter_config: PlatformFilterConfig;
+  resume_config: ResumeConfig;
+  greet_config: GreetConfig;
+  replay_config: ReplayConfig;
+}
+
 export interface AppRuntimeConfig {
   schema_version: number;
   onboarding_completed: boolean;
@@ -165,6 +178,47 @@ export interface AppRuntimeConfig {
   replay_config: ReplayConfig;
   browser_config: BrowserConfig;
   resume_config: ResumeConfig;
+  /** 旧配置/测试 mock 可能暂时不包含这两个字段，读取时请使用 getJobProfiles。 */
+  job_profiles?: JobProfile[];
+  default_job_profile_id?: string;
+}
+
+/** 把旧版顶层求职配置投影为默认方案，供迁移期 UI 安全读取。 */
+export function getJobProfiles(config: AppRuntimeConfig): JobProfile[] {
+  if (config.job_profiles?.length) return config.job_profiles;
+  return [{
+    id: config.default_job_profile_id || "default",
+    name: "默认求职方案",
+    description: "由原有求职配置自动生成",
+    archived: false,
+    job_filter_config: config.job_filter_config,
+    platform_filter_config: config.platform_filter_config,
+    resume_config: config.resume_config,
+    greet_config: config.greet_config,
+    replay_config: config.replay_config,
+  }];
+}
+
+export function getDefaultJobProfile(config: AppRuntimeConfig): JobProfile {
+  const profiles = getJobProfiles(config);
+  return profiles.find((profile) => profile.id === config.default_job_profile_id && !profile.archived)
+    ?? profiles.find((profile) => !profile.archived)
+    ?? profiles[0];
+}
+
+export function copyJobProfile(source: JobProfile, id: string, suffix: string): JobProfile {
+  return {
+    ...structuredClone(source),
+    id,
+    name: `${source.name} · ${suffix}`,
+    archived: false,
+  };
+}
+
+export function selectProfileAfterRemoval(profiles: JobProfile[], removedId: string): JobProfile | null {
+  return profiles.find((profile) => profile.id !== removedId && !profile.archived)
+    ?? profiles.find((profile) => profile.id !== removedId)
+    ?? null;
 }
 
 export type StatusKind = "idle" | "loading" | "saved" | "error";

--- a/src/types/data-management.ts
+++ b/src/types/data-management.ts
@@ -3,6 +3,7 @@ export interface BackupStats {
   chat_messages_count: number;
   interview_analyses_count: number;
   user_resumes_count: number;
+  job_profile_snapshots_count?: number;
 }
 
 export interface ExportManifest {
@@ -21,6 +22,8 @@ export interface ImportResultStats {
   interview_analyses_updated: number;
   user_resumes_added: number;
   config_imported: boolean;
+  job_profile_snapshots_added?: number;
+  job_profile_snapshots_updated?: number;
 }
 
 export type ImportStrategy = "merge" | "overwrite";

--- a/src/types/rpa.test.ts
+++ b/src/types/rpa.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { JobTaskInfo, JobTaskState, PlatformKind } from "./rpa";
+import {
+  countJobTasks,
+  getActiveTaskForPlatform,
+  isActiveJobTask,
+} from "./rpa";
+
+function task(
+  taskId: string,
+  platform: PlatformKind,
+  status: JobTaskState,
+): JobTaskInfo {
+  return {
+    task_id: taskId,
+    platform,
+    mode: "job_hunting",
+    status,
+    created_at: "2026-08-13T00:00:00Z",
+    started_at: null,
+    finished_at: null,
+    error: null,
+  };
+}
+
+describe("job task overview helpers", () => {
+  it.each(["queued", "starting", "running", "stopping"] as const)(
+    "treats %s as active",
+    (status) => expect(isActiveJobTask(task("active", "boss", status))).toBe(true),
+  );
+
+  it.each(["succeeded", "failed", "cancelled"] as const)(
+    "treats %s as terminal",
+    (status) => expect(isActiveJobTask(task("finished", "boss", status))).toBe(false),
+  );
+
+  it("isolates active tasks by platform", () => {
+    const tasks = [
+      task("boss-running", "boss", "running"),
+      task("liepin-finished", "liepin", "succeeded"),
+    ];
+
+    expect(getActiveTaskForPlatform(tasks, "boss")?.task_id).toBe("boss-running");
+    expect(getActiveTaskForPlatform(tasks, "liepin")).toBeNull();
+  });
+
+  it("counts queued and executing tasks without including terminal history", () => {
+    const counts = countJobTasks([
+      task("boss-running", "boss", "running"),
+      task("liepin-queued", "liepin", "queued"),
+      task("old-failure", "boss", "failed"),
+    ]);
+
+    expect(counts).toEqual({ active: 2, running: 1, queued: 1 });
+  });
+});

--- a/src/types/rpa.ts
+++ b/src/types/rpa.ts
@@ -35,6 +35,10 @@ export interface JobTaskInfo {
   started_at: string | null;
   finished_at: string | null;
   error: string | null;
+  /** 求职任务绑定的方案快照；回复未读等路由任务为空。 */
+  profile_id?: string | null;
+  profile_name?: string | null;
+  profile_snapshot_id?: string | null;
 }
 
 export interface JobTaskOverview {

--- a/src/types/rpa.ts
+++ b/src/types/rpa.ts
@@ -17,9 +17,73 @@ export type FlowMode =
   | "sync_chat_history"
   | "periodic_job_hunting";
 
-export interface JobTaskStatus {
-  running: boolean;
-  stopping: boolean;
+export type JobTaskState =
+  | "queued"
+  | "starting"
+  | "running"
+  | "stopping"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export interface JobTaskInfo {
+  task_id: string;
+  platform: PlatformKind;
+  mode: FlowMode;
+  status: JobTaskState;
+  created_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+  error: string | null;
+}
+
+export interface JobTaskOverview {
+  tasks: JobTaskInfo[];
+  running_count: number;
+  queued_count: number;
+  max_parallel_tasks: number;
+}
+
+export const ACTIVE_JOB_TASK_STATES: ReadonlySet<JobTaskState> = new Set([
+  "queued",
+  "starting",
+  "running",
+  "stopping",
+]);
+
+export const RUNNING_JOB_TASK_STATES: ReadonlySet<JobTaskState> = new Set([
+  "starting",
+  "running",
+  "stopping",
+]);
+
+export function isActiveJobTask(task: Pick<JobTaskInfo, "status">): boolean {
+  return ACTIVE_JOB_TASK_STATES.has(task.status);
+}
+
+export function getActiveTaskForPlatform(
+  tasks: JobTaskInfo[],
+  platform: PlatformKind,
+): JobTaskInfo | null {
+  return tasks.find(
+    (task) => task.platform === platform && isActiveJobTask(task),
+  ) ?? null;
+}
+
+export function countJobTasks(tasks: JobTaskInfo[]): {
+  active: number;
+  running: number;
+  queued: number;
+} {
+  return tasks.reduce(
+    (counts, task) => {
+      if (isActiveJobTask(task)) counts.active += 1;
+      if (RUNNING_JOB_TASK_STATES.has(task.status)) counts.running += 1;
+      if (task.status === "queued") counts.queued += 1;
+      return counts;
+    },
+    { active: 0, running: 0, queued: 0 },
+  );
 }
 
 export interface BrowserEnvStatus {

--- a/src/view/config/DataManagementPanel.tsx
+++ b/src/view/config/DataManagementPanel.tsx
@@ -189,7 +189,7 @@ export function DataManagementPanel() {
                 checked={includeConfig}
                 onChange={(e) => setIncludeConfig(e.target.checked)}
               >
-                同时导出应用系统全局配置 (包含打招呼/自动回复模板与岗位筛选规则)
+                同时导出应用配置（包含求职方案、话术与岗位筛选规则）
               </Checkbox>
             </Space>
             <div>
@@ -259,6 +259,9 @@ export function DataManagementPanel() {
               <Descriptions.Item label="简历快照与模板">
                 {previewManifest.stats.user_resumes_count} 个
               </Descriptions.Item>
+              <Descriptions.Item label="求职方案执行快照">
+                {previewManifest.stats.job_profile_snapshots_count ?? 0} 个
+              </Descriptions.Item>
             </Descriptions>
 
             <Divider style={{ margin: "12px 0" }} />
@@ -295,7 +298,7 @@ export function DataManagementPanel() {
                   checked={importConfig}
                   onChange={(e) => setImportConfig(e.target.checked)}
                 >
-                  同步覆盖更新系统配置 (打招呼与筛选规则)
+                  同步覆盖更新应用配置（包含求职方案、话术与筛选规则）
                 </Checkbox>
               </div>
             )}

--- a/src/view/config/index.tsx
+++ b/src/view/config/index.tsx
@@ -16,6 +16,10 @@ import {
   Cascader,
   Collapse,
   Alert,
+  Dropdown,
+  Modal,
+  Tabs,
+  Tag,
   message as antdMessage,
 } from "antd";
 import {
@@ -33,6 +37,8 @@ import {
   BrowserConfig,
   ResumeConfig,
   RegexRule,
+  JobProfile,
+  getJobProfiles,
 } from "@/types/app-config";
 import {
   jobTypeOptions,
@@ -62,6 +68,11 @@ import {
   ArrowDownOutlined,
   EyeOutlined,
   EyeInvisibleOutlined,
+  CopyOutlined,
+  MoreOutlined,
+  EditOutlined,
+  StarOutlined,
+  InboxOutlined,
 } from "@ant-design/icons";
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
@@ -175,6 +186,14 @@ export interface ConfigPageProps {
   removeRule: (index: number) => void;
   importConfig: (path: string) => Promise<void>;
   exportConfig: (path: string) => Promise<void>;
+  activeProfileId: string;
+  onSelectProfile: (id: string) => void;
+  onCreateProfile: (meta: Pick<JobProfile, "name" | "description">) => void;
+  onDuplicateProfile: () => void;
+  onUpdateProfileMeta: (next: Partial<Pick<JobProfile, "name" | "description">>) => void;
+  onSetDefaultProfile: () => void;
+  onArchiveProfile: () => void;
+  onDeleteProfile: () => void;
 }
 
 const configGroupKeys = [
@@ -195,24 +214,29 @@ const toVisibleConfigGroup = (group?: ConfigGroup): VisibleConfigGroup =>
     : "resume";
 
 const menuItems = [
-  { type: "group" as const, label: "基础环境", children: [
-    { key: "browser", icon: <GlobalOutlined />, label: "浏览器环境" },
+  { type: "group" as const, label: "求职设置", children: [
+    { key: "profile", icon: <ProductOutlined />, label: "求职方案" },
+  ] },
+  { type: "group" as const, label: "系统能力", children: [
     { key: "llm", icon: <RobotOutlined />, label: "大模型" },
+    { key: "browser", icon: <GlobalOutlined />, label: "浏览器环境" },
   ] },
-  { type: "group" as const, label: "求职策略", children: [
-    { key: "job", icon: <ProductOutlined />, label: "岗位筛选" },
-    { key: "resume", icon: <FilePdfOutlined />, label: "简历配置" },
-  ] },
-  { type: "group" as const, label: "沟通策略", children: [
-    { key: "greet", icon: <CommentOutlined />, label: "打招呼配置" },
-    { key: "reply", icon: <CommentOutlined />, label: "自动回复" },
-  ] },
-  { type: "group" as const, label: "数据管理", children: [
+  { type: "group" as const, label: "数据与应用", children: [
     { key: "data", icon: <DatabaseOutlined />, label: "备份与设备共享" },
-  ] },
-  { type: "group" as const, label: "系统信息", children: [
     { key: "about", icon: <InfoCircleOutlined />, label: "软件与更新" },
   ] },
+];
+
+const profileGroupKeys = ["job", "resume", "greet", "reply"] as const;
+type ProfileGroup = (typeof profileGroupKeys)[number];
+const isProfileGroup = (group: VisibleConfigGroup): group is ProfileGroup =>
+  profileGroupKeys.includes(group as ProfileGroup);
+
+const profileTabItems = [
+  { key: "job", icon: <ProductOutlined />, label: "岗位筛选" },
+  { key: "resume", icon: <FilePdfOutlined />, label: "简历配置" },
+  { key: "greet", icon: <CommentOutlined />, label: "打招呼" },
+  { key: "reply", icon: <CommentOutlined />, label: "自动回复" },
 ];
 
 export function ConfigPage(props: ConfigPageProps) {
@@ -224,6 +248,58 @@ export function ConfigPage(props: ConfigPageProps) {
     useState<BrowserEnvStatus | null>(null);
   const [ruleRequirement, setRuleRequirement] = useState("");
   const [generatingRules, setGeneratingRules] = useState(false);
+  const [profileModalMode, setProfileModalMode] = useState<"create" | "edit" | null>(null);
+  const [profileDraft, setProfileDraft] = useState({ name: "", description: "" });
+  const profiles = getJobProfiles(props.config);
+  const activeProfile = profiles.find((profile) => profile.id === props.activeProfileId)
+    ?? profiles[0];
+  const defaultProfileId = props.config.default_job_profile_id || profiles[0]?.id;
+  const canArchive = activeProfile.id !== defaultProfileId && !activeProfile.archived;
+  const canDelete = profiles.length > 1 && activeProfile.id !== defaultProfileId;
+
+  const openProfileModal = (mode: "create" | "edit") => {
+    setProfileModalMode(mode);
+    setProfileDraft(mode === "edit"
+      ? { name: activeProfile.name, description: activeProfile.description ?? "" }
+      : { name: "", description: "" });
+  };
+
+  const saveProfileMeta = () => {
+    const name = profileDraft.name.trim();
+    if (!name) {
+      antdMessage.warning("请输入方案名称");
+      return;
+    }
+    const meta = { name, description: profileDraft.description.trim() || null };
+    if (profileModalMode === "create") props.onCreateProfile(meta);
+    if (profileModalMode === "edit") props.onUpdateProfileMeta(meta);
+    setProfileModalMode(null);
+  };
+
+  const handleProfileAction = ({ key }: { key: string }) => {
+    if (key === "edit") openProfileModal("edit");
+    if (key === "duplicate") props.onDuplicateProfile();
+    if (key === "default") props.onSetDefaultProfile();
+    if (key === "archive") {
+      Modal.confirm({
+        title: "归档这张求职方案？",
+        content: "归档后不会出现在新任务的方案列表中，历史任务和会话仍可继续使用。",
+        okText: "确认归档",
+        cancelText: "取消",
+        onOk: props.onArchiveProfile,
+      });
+    }
+    if (key === "delete") {
+      Modal.confirm({
+        title: "删除这张求职方案？",
+        content: "删除后无法恢复；已入队任务仍会使用原有执行快照。",
+        okText: "删除",
+        cancelText: "取消",
+        okButtonProps: { danger: true },
+        onOk: props.onDeleteProfile,
+      });
+    }
+  };
 
   useEffect(() => {
     setActiveGroup(toVisibleConfigGroup(props.initialGroup));
@@ -1641,8 +1717,8 @@ export function ConfigPage(props: ConfigPageProps) {
   };
 
   return (
-    <div className="flex h-full w-full flex-col md:flex-row gap-6 animate-in">
-      <aside className="w-full md:w-[260px] flex-shrink-0 flex flex-col gap-4">
+    <div className="flex h-full w-full flex-col gap-5 md:flex-row animate-in">
+      <aside className="flex w-full flex-shrink-0 flex-col gap-3 md:w-[220px]">
         <div className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-500">
           {props.status === "loading" ? (
             <><LoadingOutlined className="mr-2 text-sky-500" />正在自动保存…</>
@@ -1656,44 +1732,134 @@ export function ConfigPage(props: ConfigPageProps) {
         </div>
         <Menu
           mode="vertical"
-          selectedKeys={[activeGroup]}
-          onSelect={({ key }) => setActiveGroup(key as VisibleConfigGroup)}
+          selectedKeys={[isProfileGroup(activeGroup) ? "profile" : activeGroup]}
+          onSelect={({ key }) => setActiveGroup(key === "profile"
+            ? (isProfileGroup(activeGroup) ? activeGroup : "job")
+            : key as VisibleConfigGroup)}
           items={menuItems}
-          className="rounded-3xl p-2 bg-white/85! border border-slate-200/80 shadow-[0_18px_40px_rgba(15,23,42,0.06)]"
+          className="rounded-2xl border border-slate-200/80 bg-white/90! p-2 shadow-[0_12px_32px_rgba(15,23,42,0.05)]"
         />
-        <Button
-          icon={<UploadOutlined />}
-          onClick={selectConfigFile}
-          className="w-full rounded-xl! h-11! border-sky-200 bg-sky-50 font-bold text-sky-700! hover:border-sky-300! hover:text-sky-800!"
-          disabled={props.status === "loading"}
-        >
-          导入配置模板
-        </Button>
-
-        <Button
-          icon={<DownloadOutlined />}
-          onClick={selectExportConfigFile}
-          className="w-full rounded-xl! h-11! border-emerald-200 bg-emerald-50 font-bold text-emerald-700! hover:border-emerald-300! hover:text-emerald-800!"
-          disabled={props.status === "loading"}
-        >
-          导出配置模板
-        </Button>
-
+        <Dropdown menu={{ items: [
+          { key: "import", icon: <UploadOutlined />, label: "导入配置模板", onClick: selectConfigFile },
+          { key: "export", icon: <DownloadOutlined />, label: "导出配置模板", onClick: selectExportConfigFile },
+        ] }} trigger={["click"]}>
+          <Button disabled={props.status === "loading"} className="h-10! w-full justify-start! text-slate-600!">
+            配置文件 <MoreOutlined className="ml-auto" />
+          </Button>
+        </Dropdown>
       </aside>
 
       <Form
         form={form}
         layout="vertical"
         requiredMark={false}
-        className="flex-1 min-w-0 h-full overflow-hidden flex flex-col"
+        className="flex h-full min-w-0 flex-1 flex-col overflow-hidden"
         onSubmitCapture={(e) => {
           e.preventDefault();
         }}
       >
-        <div className="flex-1 h-full overflow-y-auto overflow-x-hidden rounded-3xl border border-slate-200/80 bg-white/82 px-6 py-6 md:px-12 md:py-10 backdrop-blur-3xl shadow-[0_24px_60px_rgba(15,23,42,0.06)]">
-          {renderContent()}
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-3xl border border-slate-200/80 bg-white/90 shadow-[0_24px_60px_rgba(15,23,42,0.06)] backdrop-blur-3xl">
+          {isProfileGroup(activeGroup) && (
+            <div className="flex-shrink-0 border-b border-slate-200 bg-white px-5 pt-5 md:px-8 md:pt-6">
+              <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                <div className="min-w-0">
+                  <Text className="mb-1 block text-[11px] font-bold uppercase tracking-[0.18em] text-sky-600">
+                    当前求职方案
+                  </Text>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Select
+                      aria-label="当前求职方案"
+                      size="large"
+                      popupMatchSelectWidth={false}
+                      className="min-w-[240px] max-w-full md:min-w-[320px]"
+                      value={activeProfile.id}
+                      onChange={props.onSelectProfile}
+                      options={profiles.map((profile) => ({
+                        value: profile.id,
+                        label: `${profile.name}${profile.id === defaultProfileId ? " · 默认" : ""}${profile.archived ? " · 已归档" : ""}`,
+                      }))}
+                    />
+                    {activeProfile.id === defaultProfileId && <Tag color="blue">默认使用</Tag>}
+                    {activeProfile.archived && <Tag>已归档</Tag>}
+                  </div>
+                  <Text type="secondary" className="mt-2 block max-w-2xl text-xs!">
+                    {activeProfile.description || "这张方案统一管理岗位筛选、简历、打招呼和自动回复。"}
+                  </Text>
+                </div>
+                <Space wrap size={8}>
+                  <Button type="primary" icon={<PlusOutlined />} onClick={() => openProfileModal("create")}>
+                    新建方案
+                  </Button>
+                  <Dropdown
+                    trigger={["click"]}
+                    menu={{
+                      onClick: handleProfileAction,
+                      items: [
+                        { key: "edit", icon: <EditOutlined />, label: "编辑名称与说明" },
+                        { key: "duplicate", icon: <CopyOutlined />, label: "复制当前方案" },
+                        { type: "divider" },
+                        { key: "default", icon: <StarOutlined />, label: activeProfile.id === defaultProfileId ? "当前已是默认方案" : "设为默认方案", disabled: activeProfile.id === defaultProfileId || activeProfile.archived },
+                        { key: "archive", icon: <InboxOutlined />, label: "归档当前方案", disabled: !canArchive },
+                        { key: "delete", icon: <DeleteOutlined />, label: "删除当前方案", danger: true, disabled: !canDelete },
+                      ],
+                    }}
+                  >
+                    <Button icon={<MoreOutlined />}>方案管理</Button>
+                  </Dropdown>
+                </Space>
+              </div>
+              <Tabs
+                className="mt-4 [&_.ant-tabs-nav]:mb-0!"
+                activeKey={activeGroup}
+                onChange={(key) => setActiveGroup(key as ProfileGroup)}
+                items={profileTabItems}
+              />
+            </div>
+          )}
+          <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-6 py-6 md:px-10 md:py-8">
+            {renderContent()}
+          </div>
         </div>
       </Form>
+      <Modal
+        title={profileModalMode === "create" ? "新建求职方案" : "编辑方案信息"}
+        open={profileModalMode !== null}
+        okText={profileModalMode === "create" ? "创建并切换" : "保存"}
+        cancelText="取消"
+        onCancel={() => setProfileModalMode(null)}
+        onOk={saveProfileMeta}
+        destroyOnHidden
+      >
+        <Space direction="vertical" size={14} className="mt-3 w-full">
+          <div className="w-full">
+            <Text strong>方案名称</Text>
+            <Input
+              autoFocus
+              className="mt-2"
+              maxLength={40}
+              placeholder="例如：新加坡 AI 应用工程师"
+              value={profileDraft.name}
+              onChange={(event) => setProfileDraft((draft) => ({ ...draft, name: event.target.value }))}
+              onPressEnter={saveProfileMeta}
+            />
+          </div>
+          <div className="w-full">
+            <Text strong>方案说明</Text>
+            <Input.TextArea
+              className="mt-2"
+              autoSize={{ minRows: 3, maxRows: 5 }}
+              maxLength={160}
+              showCount
+              placeholder="说明目标岗位、地区或这张方案的使用场景"
+              value={profileDraft.description}
+              onChange={(event) => setProfileDraft((draft) => ({ ...draft, description: event.target.value }))}
+            />
+          </div>
+          {profileModalMode === "create" && (
+            <Alert type="info" showIcon message="新方案会复制默认方案的当前配置，你可以创建后分别调整。" />
+          )}
+        </Space>
+      </Modal>
     </div>
   );
 }

--- a/src/view/config/index.tsx
+++ b/src/view/config/index.tsx
@@ -1538,6 +1538,31 @@ export function ConfigPage(props: ConfigPageProps) {
                 }
               />
             </Form.Item>
+            <Form.Item
+              label="最大并行任务数"
+              name={["browser_config", "max_parallel_tasks"]}
+              extra="默认为 2, BOSS 与猎聘可各运行一个任务、同一平台的后续任务会排队。"
+            >
+              <InputNumber
+                min={1}
+                max={2}
+                precision={0}
+                style={{ width: "100%" }}
+                onChange={(value) =>
+                  props.updateBrowser({ max_parallel_tasks: value ?? 2 })
+                }
+              />
+            </Form.Item>
+            <Alert
+              type="info"
+              showIcon
+              message={
+                props.config.browser_config.max_parallel_tasks === 1
+                  ? "单任务模式：预计浏览器占用约 550～900 MB"
+                  : "双任务模式：预计浏览器占用约 750 MB～1.3 GB"
+              }
+              description="任务共享一个受管 Chrome，但使用独立连接和标签页；实际占用取决于页面、图片和聊天记录数量。"
+            />
           </Space>
         );
       case "resume":

--- a/src/view/workspace/index.tsx
+++ b/src/view/workspace/index.tsx
@@ -25,7 +25,6 @@ import {
   PlayCircleOutlined,
   RocketOutlined,
   SendOutlined,
-  StopOutlined,
   WarningOutlined,
 } from "@ant-design/icons";
 import { invoke } from "@tauri-apps/api/core";
@@ -36,10 +35,13 @@ import type {
   EnvCheckStep,
   EnvCheckStatus,
   FlowMode,
-  JobTaskStatus,
+  JobTaskInfo,
+  JobTaskOverview,
   PlatformKind,
-  ReadinessItem,
-  ReadinessReport,
+} from "../../types/rpa";
+import {
+  countJobTasks,
+  isActiveJobTask,
 } from "../../types/rpa";
 import type { JobDetail } from "../../types/job-detail";
 
@@ -50,7 +52,13 @@ interface StepInfo {
   status: EnvCheckStep;
 }
 
-type LogFilter = "all" | PlatformKind;
+interface PlatformEnvState {
+  phase: CheckPhase;
+  result: EnvCheckResult | null;
+  message: string;
+}
+
+type QueueFilter = "all" | PlatformKind;
 
 interface PlatformMeta {
   label: string;
@@ -133,29 +141,88 @@ const FLOW_MODE_OPTIONS: FlowModeOption[] = [
   },
 ];
 
-const LOG_FILTER_OPTIONS: { value: LogFilter; label: string }[] = [
-  { value: "all", label: "全部" },
-  { value: "boss", label: "BOSS" },
-  { value: "liepin", label: "猎聘" },
-];
-
 function getFlowModeLabel(mode: FlowMode): string {
   return FLOW_MODE_OPTIONS.find((option) => option.key === mode)?.label ?? "自动求职";
 }
 
-function lineMatchesPlatform(line: string, target: PlatformKind): boolean {
-  return target === "liepin" ? line.includes("[猎聘]") : line.includes("[BOSS]");
-}
-
-function filterLogContent(content: string, filter: LogFilter): string {
-  if (!content.trim() || filter === "all") {
+export function filterTaskLogContent(
+  content: string,
+  taskId: string | null,
+): string {
+  if (!content.trim() || !taskId) {
     return content;
   }
 
   return content
     .split("\n")
-    .filter((line) => lineMatchesPlatform(line, filter))
+    .filter((line) => line.includes(`[task=${taskId}]`))
     .join("\n");
+}
+
+const TASK_STATE_ORDER: Record<JobTaskInfo["status"], number> = {
+  running: 0,
+  starting: 0,
+  stopping: 0,
+  queued: 1,
+  failed: 2,
+  cancelled: 2,
+  succeeded: 2,
+};
+
+const PLATFORM_ORDER: PlatformKind[] = ["boss", "liepin"];
+
+export function sortTasksForQueue(tasks: JobTaskInfo[]): JobTaskInfo[] {
+  return [...tasks].sort((left, right) => {
+    const stateOrder = TASK_STATE_ORDER[left.status] - TASK_STATE_ORDER[right.status];
+    if (stateOrder !== 0) return stateOrder;
+    if (left.status === "queued" && right.status === "queued") {
+      return left.created_at.localeCompare(right.created_at);
+    }
+    return right.created_at.localeCompare(left.created_at);
+  });
+}
+
+export function sortTasksNewestFirst(tasks: JobTaskInfo[]): JobTaskInfo[] {
+  return [...tasks].sort((left, right) =>
+    right.created_at.localeCompare(left.created_at),
+  );
+}
+
+export function filterTasksByPlatform(
+  tasks: JobTaskInfo[],
+  filter: QueueFilter,
+): JobTaskInfo[] {
+  return filter === "all"
+    ? tasks
+    : tasks.filter((task) => task.platform === filter);
+}
+
+function taskStateLabel(status: JobTaskInfo["status"]): string {
+  return {
+    queued: "排队中",
+    starting: "启动中",
+    running: "运行中",
+    stopping: "停止中",
+    succeeded: "已完成",
+    failed: "失败",
+    cancelled: "已取消",
+  }[status];
+}
+
+function taskStateColor(status: JobTaskInfo["status"]): string {
+  return {
+    queued: "default",
+    starting: "processing",
+    running: "processing",
+    stopping: "warning",
+    succeeded: "success",
+    failed: "error",
+    cancelled: "default",
+  }[status];
+}
+
+export function requestStopJobTask(taskId: string): Promise<CommandResult<void>> {
+  return invoke<CommandResult<void>>("stop_job_task", { taskId });
 }
 
 /* ────────── Stat tile helper ────────── */
@@ -172,32 +239,38 @@ interface StatTile {
 /* ────────── Component ────────── */
 
 const WorkspacePage = ({
-  onOpenConfig,
 }: {
   onNavigate?: (tab: "job-data") => void;
   onOpenConfig?: (group: "resume" | "llm" | "job" | "greet" | "reply" | "browser") => void;
 }) => {
-  const [checkPhase, setCheckPhase] = useState<CheckPhase>("idle");
-  const [envResult, setEnvResult] = useState<EnvCheckResult | null>(null);
-  const [taskRunning, setTaskRunning] = useState(false);
-  const [taskStopping, setTaskStopping] = useState(false);
-  const [runningPlatform, setRunningPlatform] = useState<PlatformKind | null>(null);
+  const [environmentStates, setEnvironmentStates] = useState<
+    Record<PlatformKind, PlatformEnvState>
+  >({
+    boss: { phase: "idle", result: null, message: "" },
+    liepin: { phase: "idle", result: null, message: "" },
+  });
+  const [taskOverview, setTaskOverview] = useState<JobTaskOverview>({
+    tasks: [],
+    running_count: 0,
+    queued_count: 0,
+    max_parallel_tasks: 2,
+  });
   const [logContent, setLogContent] = useState("");
-  const [checkMsg, setCheckMsg] = useState("");
   const [startModalOpen, setStartModalOpen] = useState(false);
   const [selectedMode, setSelectedMode] = useState<FlowMode>("job_hunting");
   const [intervalMinutes, setIntervalMinutes] = useState<number>(30);
   const [platform, setPlatform] = useState<PlatformKind>("boss");
-  const [logFilter, setLogFilter] = useState<LogFilter>("boss");
-  const [readiness, setReadiness] = useState<ReadinessReport | null>(null);
-  // 弹窗打开时的预检加载态，与确认按钮的 confirmLoading 分开，避免互相干扰
-  const [readinessLoading, setReadinessLoading] = useState(false);
-  // 是否展开「已就绪」的检查明细
-  const [readyDetailsOpen, setReadyDetailsOpen] = useState(false);
-  const [preflightLoading, setPreflightLoading] = useState(false);
+  const [modalPlatform, setModalPlatform] = useState<PlatformKind>("boss");
+  const [pendingStartPlatforms, setPendingStartPlatforms] = useState<
+    Partial<Record<PlatformKind, boolean>>
+  >({});
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [queueFilter, setQueueFilter] = useState<QueueFilter>("all");
   const [jobs, setJobs] = useState<JobDetail[]>([]);
   const [logCollapsed, setLogCollapsed] = useState(true);
   const logRef = useRef<HTMLPreElement>(null);
+  const previousActiveTaskIdsRef = useRef<Set<string>>(new Set());
+  const taskRefreshPromiseRef = useRef<Promise<void> | null>(null);
   const [messageApi, contextHolder] = message.useMessage();
 
   const loadJobs = useCallback(async () => {
@@ -211,26 +284,38 @@ const WorkspacePage = ({
     }
   }, []);
 
-  const refreshTaskStatus = useCallback(async () => {
-    try {
-      const result = await invoke<CommandResult<JobTaskStatus>>(
-        "get_job_task_status",
-      );
-      if (result.success && result.data) {
-        const running = result.data.running;
-        const stopping = result.data.stopping;
-        setTaskRunning((wasRunning) => {
-          // Reload jobs whenever task state flips (stat stale remediation).
-          if (wasRunning !== running) void loadJobs();
-          return running;
-        });
-        setTaskStopping(running && stopping);
-        setRunningPlatform((current) => running ? current ?? platform : null);
+  const refreshTaskStatus = useCallback((): Promise<void> => {
+    if (taskRefreshPromiseRef.current) return taskRefreshPromiseRef.current;
+
+    const request = (async () => {
+      try {
+        const result = await invoke<CommandResult<JobTaskOverview>>(
+          "get_job_task_status",
+        );
+        if (result.success && result.data) {
+          const nextActiveIds = new Set(
+            result.data.tasks.filter(isActiveJobTask).map((task) => task.task_id),
+          );
+          const taskFinished = [...previousActiveTaskIdsRef.current].some(
+            (taskId) => !nextActiveIds.has(taskId),
+          );
+          previousActiveTaskIdsRef.current = nextActiveIds;
+          setTaskOverview(result.data);
+          if (taskFinished) await loadJobs();
+        }
+      } catch {
+        // A transient poll failure must not tear down the dashboard polling loop.
       }
-    } catch {
-      // ignore
-    }
-  }, [loadJobs, platform]);
+    })();
+
+    taskRefreshPromiseRef.current = request;
+    void request.then(() => {
+      if (taskRefreshPromiseRef.current === request) {
+        taskRefreshPromiseRef.current = null;
+      }
+    });
+    return request;
+  }, [loadJobs]);
 
   const refreshLog = useCallback(async () => {
     try {
@@ -247,18 +332,18 @@ const WorkspacePage = ({
 
   useEffect(() => {
     void loadJobs();
-    void refreshLog();
-    void refreshTaskStatus();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      void refreshLog();
-      void refreshTaskStatus();
-    }, 2000);
-    return () => clearInterval(timer);
-  }, [refreshLog, refreshTaskStatus]);
+    let disposed = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const poll = async () => {
+      await Promise.all([refreshLog(), refreshTaskStatus()]);
+      if (!disposed) timer = setTimeout(() => void poll(), 2000);
+    };
+    void poll();
+    return () => {
+      disposed = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [loadJobs, refreshLog, refreshTaskStatus]);
 
   useEffect(() => {
     if (logRef.current) {
@@ -266,254 +351,173 @@ const WorkspacePage = ({
     }
   }, [logContent]);
 
-  const handleCheckEnv = useCallback(async () => {
-    setCheckPhase("checking");
-    setEnvResult(null);
-    setCheckMsg("");
+  const handleCheckEnv = useCallback(async (targetPlatform: PlatformKind) => {
+    setEnvironmentStates((current) => ({
+      ...current,
+      [targetPlatform]: { phase: "checking", result: null, message: "" },
+    }));
     try {
       const result = await invoke<CommandResult<EnvCheckResult>>("check_env", {
-        platform,
+        platform: targetPlatform,
       });
       if (!result.success || result.data === null) {
-        setCheckPhase("done");
         const errorMessage = commandErrorMessage(result.error, "环境检查失败");
-        setCheckMsg(errorMessage);
+        setEnvironmentStates((current) => ({
+          ...current,
+          [targetPlatform]: { phase: "done", result: null, message: errorMessage },
+        }));
         messageApi.error(errorMessage);
         return;
       }
-      setEnvResult(result.data);
-      setCheckPhase("done");
+      setEnvironmentStates((current) => ({
+        ...current,
+        [targetPlatform]: { phase: "done", result: result.data, message: "" },
+      }));
       if (result.data.status === "completed") {
-        messageApi.success(`${PLATFORM_META[platform].label} 环境检查通过`);
+        messageApi.success(`${PLATFORM_META[targetPlatform].label} 环境检查通过`);
       }
     } catch (error: unknown) {
-      const msg =
-        error instanceof Error ? error.message : "环境检查异常";
-      setCheckPhase("done");
-      setCheckMsg(msg);
+      const msg = error instanceof Error ? error.message : "环境检查异常";
+      setEnvironmentStates((current) => ({
+        ...current,
+        [targetPlatform]: { phase: "done", result: null, message: msg },
+      }));
       messageApi.error(msg);
     }
-  }, [messageApi, platform]);
+  }, [messageApi]);
 
   const handleRpaFlow = useCallback(
-    async (mode: FlowMode, intervalMinutes?: number) => {
-      const startedPlatform = platform;
-      setTaskRunning(true);
-      setTaskStopping(false);
-      setRunningPlatform(startedPlatform);
+    async (
+      startedPlatform: PlatformKind,
+      mode: FlowMode,
+      intervalMinutes?: number,
+    ) => {
+      setPendingStartPlatforms((current) => ({
+        ...current,
+        [startedPlatform]: true,
+      }));
       try {
-        const result = await invoke<CommandResult<void>>("rpa_flow", {
+        const result = await invoke<CommandResult<JobTaskInfo>>("start_job_task", {
           platform: startedPlatform,
           mode,
           intervalMinutes: mode === "periodic_job_hunting" ? intervalMinutes : undefined,
         });
-        if (!result.success) {
+        if (!result.success || !result.data) {
           messageApi.error(commandErrorMessage(result.error, "启动失败"));
-          setTaskRunning(false);
-          setTaskStopping(false);
-          setRunningPlatform(null);
           return;
         }
-        setTaskRunning(false);
-        setTaskStopping(false);
-        setRunningPlatform(null);
-        void loadJobs();
-        messageApi.success(`${PLATFORM_META[startedPlatform].label} ${getFlowModeLabel(mode)}已完成`);
+        await refreshTaskStatus();
+        messageApi.success(
+          `${PLATFORM_META[startedPlatform].label} ${getFlowModeLabel(mode)}已加入任务队列`,
+        );
       } catch (error: unknown) {
-        setTaskRunning(false);
-        setRunningPlatform(null);
         messageApi.error(
           error instanceof Error ? error.message : "启动失败",
         );
+      } finally {
+        setPendingStartPlatforms((current) => ({
+          ...current,
+          [startedPlatform]: false,
+        }));
       }
     },
-    [loadJobs, messageApi, platform],
+    [messageApi, refreshTaskStatus],
   );
 
-  /** 执行一次启动前预检，失败时给出提示并返回 null */
-  const runPreflight = useCallback(
-    async (
-      targetPlatform: PlatformKind,
-      targetMode: FlowMode,
-    ): Promise<ReadinessReport | null> => {
-      try {
-        const result = await invoke<CommandResult<ReadinessReport>>("preflight_job_task", {
-          platform: targetPlatform,
-          mode: targetMode,
-        });
-        if (!result.success || !result.data) {
-          messageApi.error(commandErrorMessage(result.error, "启动前检查失败"));
-          return null;
-        }
-        return result.data;
-      } catch (error) {
-        messageApi.error(error instanceof Error ? error.message : "启动前检查失败");
-        return null;
-      }
-    },
-    [messageApi],
-  );
-
-  /** 打开启动弹窗：只负责清空上一次的过期结果，预检交由下方 useEffect 统一触发 */
-  const openStartModal = useCallback(() => {
-    setReadiness(null);
-    setReadyDetailsOpen(false);
+  /** 打开启动弹窗。环境状态由左侧按钮显式检查，不在弹窗重复请求。 */
+  const openStartModal = useCallback((targetPlatform: PlatformKind) => {
+    setModalPlatform(targetPlatform);
+    setSelectedMode("job_hunting");
     setStartModalOpen(true);
   }, []);
 
-  /** 关闭启动弹窗并清空预检结果，避免下次打开时展示过期数据 */
   const closeStartModal = useCallback(() => {
     setStartModalOpen(false);
-    setReadiness(null);
-    setReadyDetailsOpen(false);
   }, []);
 
-  // 弹窗打开期间（含打开瞬间、切换模式、切换平台）自动跑预检
-  useEffect(() => {
-    if (!startModalOpen) return;
-    let cancelled = false;
-    setReadinessLoading(true);
-    void (async () => {
-      const report = await runPreflight(platform, selectedMode);
-      if (cancelled) return;
-      setReadiness(report);
-      setReadyDetailsOpen(false);
-      setReadinessLoading(false);
-    })();
-    return () => {
-      // 快速切换模式/平台时丢弃过期响应
-      cancelled = true;
-    };
-  }, [startModalOpen, selectedMode, platform, runPreflight]);
-
   const handleStartConfirm = useCallback(async () => {
-    setPreflightLoading(true);
-    try {
-      // 确认时再跑一次，避免用户在弹窗停留期间修改了配置
-      const report = await runPreflight(platform, selectedMode);
-      if (!report) return;
-      setReadiness(report);
-      setReadyDetailsOpen(false);
-      if (!report.ready) {
-        messageApi.warning("准备工作尚未完成，请处理阻塞项后重试");
-        return;
-      }
-      closeStartModal();
-      await handleRpaFlow(
-        selectedMode,
-        selectedMode === "periodic_job_hunting" ? intervalMinutes : undefined,
-      );
-    } finally {
-      setPreflightLoading(false);
-    }
+    closeStartModal();
+    await handleRpaFlow(
+      modalPlatform,
+      selectedMode,
+      selectedMode === "periodic_job_hunting" ? intervalMinutes : undefined,
+    );
   }, [
     closeStartModal,
     handleRpaFlow,
     intervalMinutes,
-    messageApi,
-    platform,
-    runPreflight,
+    modalPlatform,
     selectedMode,
   ]);
 
-  const handleStopTask = useCallback(async () => {
+  const handleStopTask = useCallback(async (taskId: string) => {
     try {
-      const result = await invoke<CommandResult<void>>("stop_job_task");
+      const result = await requestStopJobTask(taskId);
       if (!result.success) {
         messageApi.error(commandErrorMessage(result.error, "停止失败"));
         return;
       }
-      setTaskStopping(true);
+      await refreshTaskStatus();
       messageApi.success("已发送停止请求");
     } catch (error: unknown) {
       messageApi.error(
         error instanceof Error ? error.message : "停止失败",
       );
     }
-  }, [messageApi]);
+  }, [messageApi, refreshTaskStatus]);
 
   const handleCopyLog = useCallback(() => {
     if (!logContent) return;
-    void navigator.clipboard.writeText(filterLogContent(logContent, logFilter));
+    void navigator.clipboard.writeText(
+      filterTaskLogContent(logContent, selectedTaskId),
+    );
     messageApi.success("日志已复制到剪贴板");
-  }, [logContent, logFilter, messageApi]);
+  }, [logContent, messageApi, selectedTaskId]);
 
-  const currentStepIndex = envResult
-    ? getStepIndex(envResult.current_step)
-    : 0;
-
-  const qrSrc = envResult?.qr_code_base64
-    ? `data:image/png;base64,${envResult.qr_code_base64}`
-    : null;
-
-  const showSteps = checkPhase !== "idle";
-  const currentPlatform = PLATFORM_META[platform];
-  const runningPlatformLabel = runningPlatform
-    ? PLATFORM_META[runningPlatform].label
-    : "当前";
-  const filteredLogContent = filterLogContent(logContent, logFilter);
-
-  /* 预检明细：默认只展示需要处理的项，已就绪项折叠 */
-  const pendingReadinessItems =
-    readiness?.items.filter((item) => item.level !== "ready") ?? [];
-  const readyReadinessItems =
-    readiness?.items.filter((item) => item.level === "ready") ?? [];
-
-  const renderReadinessItem = (item: ReadinessItem) => (
-    <div
-      key={item.key}
-      style={{ display: "flex", justifyContent: "space-between", gap: 12 }}
-    >
-      <Typography.Text
-        type={
-          item.level === "blocked"
-            ? "danger"
-            : item.level === "warning"
-              ? "warning"
-              : "success"
-        }
-      >
-        {item.label}：{item.message}
-      </Typography.Text>
-      {item.level !== "ready" && item.config_group && onOpenConfig && (
-        <Button
-          size="small"
-          type="link"
-          onClick={() =>
-            onOpenConfig(
-              item.config_group as
-                | "resume"
-                | "llm"
-                | "job"
-                | "greet"
-                | "reply"
-                | "browser",
-            )
-          }
-        >
-          前往配置
-        </Button>
-      )}
-    </div>
+  const activeTasks = taskOverview.tasks.filter(isActiveJobTask);
+  const taskCounts = countJobTasks(taskOverview.tasks);
+  const modalTaskStartPending = pendingStartPlatforms[modalPlatform] === true;
+  const queueTasks = sortTasksNewestFirst(taskOverview.tasks);
+  const visibleQueueTasks = filterTasksByPlatform(queueTasks, queueFilter);
+  const queuedTasksInExecutionOrder = sortTasksForQueue(taskOverview.tasks).filter(
+    (task) => task.status === "queued",
   );
+  const currentPlatformMeta = PLATFORM_META[platform];
+  const currentEnvironment = environmentStates[platform];
+  const currentPlatformHasActiveTask = activeTasks.some(
+    (task) => task.platform === platform,
+  );
+  const currentStartPending = pendingStartPlatforms[platform] === true;
+  const currentStepIndex = currentEnvironment.result
+    ? getStepIndex(currentEnvironment.result.current_step)
+    : 0;
+  const currentQrSrc = currentEnvironment.result?.qr_code_base64
+    ? `data:image/png;base64,${currentEnvironment.result.qr_code_base64}`
+    : null;
+  const selectedTask = selectedTaskId
+    ? taskOverview.tasks.find((task) => task.task_id === selectedTaskId) ?? null
+    : null;
+  const filteredLogContent = filterTaskLogContent(logContent, selectedTaskId);
 
   /* derived stats */
   const totalJobs = jobs.length;
   const sentCount = jobs.filter((j) => j.is_send_resume).length;
   const repliedCount = jobs.filter((j) => j.is_reply).length;
   const replyRate = totalJobs > 0 ? `${((repliedCount / totalJobs) * 100).toFixed(0)}%` : "—";
-  const runningModeLabel = taskRunning && runningPlatform
-    ? `${PLATFORM_META[runningPlatform].shortLabel} ${taskStopping ? "停止中" : "运行中"}`
-    : "空闲";
+  const runningModeLabel = `${taskCounts.running} / ${taskOverview.max_parallel_tasks}`;
 
   const statTiles: StatTile[] = [
     {
       label: "运行状态",
       value: runningModeLabel,
-      subtitle: taskRunning ? (taskStopping ? "正在安全结束当前步骤" : "任务进行中") : "等待启动",
+      subtitle: taskCounts.queued > 0
+        ? `${taskCounts.queued} 个任务排队中`
+        : taskCounts.active > 0
+          ? `${taskCounts.active} 个活动任务`
+          : "等待启动",
       icon: <RocketOutlined style={{ fontSize: 18 }} />,
-      color: taskRunning ? "#1677ff" : "#64748b",
-      bg: taskRunning ? "rgba(22,119,255,0.1)" : "rgba(148,163,184,0.1)",
+      color: activeTasks.length > 0 ? "#1677ff" : "#64748b",
+      bg: activeTasks.length > 0 ? "rgba(22,119,255,0.1)" : "rgba(148,163,184,0.1)",
     },
     {
       label: "已建联岗位",
@@ -568,282 +572,233 @@ const WorkspacePage = ({
         ))}
       </section>
 
-      {/* ── Platform + environment check ── */}
+      {/* ── Platform card + task queue ── */}
       <section
         style={{
-          flex: "0 0 auto",
           display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
+          gridTemplateColumns: "minmax(380px, 1fr) minmax(440px, 1.15fr)",
           gap: 16,
-          alignItems: "stretch",
+          alignItems: "start",
         }}
       >
-        <Card styles={{ body: { padding: 18 } }}>
-          <Space direction="vertical" size={12} style={{ width: "100%" }}>
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-              <Typography.Text strong style={{ fontSize: 15 }}>平台选择</Typography.Text>
-              {taskRunning ? (
-                <Tag color={taskStopping ? "warning" : "processing"}>{runningPlatformLabel} {taskStopping ? "停止中" : "运行中"}</Tag>
-              ) : (
-                <Tag color="success">就绪</Tag>
-              )}
-            </div>
+        <Card
+          styles={{ body: { padding: 20, height: "100%" } }}
+          style={{
+            borderTop: `4px solid ${currentPlatformMeta.accent}`,
+            background: "linear-gradient(180deg, #ffffff 0%, #fbfdff 100%)",
+          }}
+        >
+          <Space direction="vertical" size={16} style={{ width: "100%" }}>
             <Segmented<PlatformKind>
               block
               value={platform}
-              disabled={taskRunning || checkPhase === "checking"}
-              options={[
-                { value: "boss", label: "BOSS 直聘" },
-                { value: "liepin", label: "猎聘" },
-              ]}
-              onChange={(nextPlatform) => {
-                setPlatform(nextPlatform);
-                if (nextPlatform !== "boss" && selectedMode === "sync_chat_history") {
-                  setSelectedMode("job_hunting");
-                }
-                setLogFilter(nextPlatform);
-                setCheckPhase("idle");
-                setEnvResult(null);
-                setCheckMsg("");
-              }}
+              options={PLATFORM_ORDER.map((value) => ({
+                value,
+                label: PLATFORM_META[value].label,
+              }))}
+              onChange={setPlatform}
             />
-            <div
-              style={{
-                borderLeft: `4px solid ${currentPlatform.accent}`,
-                paddingLeft: 12,
-                marginTop: 4,
-                background: "rgba(248, 250, 252, 0.8)",
-                padding: "10px 12px",
-                borderRadius: "0 8px 8px 0",
-              }}
-            >
-              <Typography.Title level={5} style={{ margin: 0, color: currentPlatform.accent }}>
-                {currentPlatform.label}
+
+            <div>
+              <Typography.Title level={4} style={{ margin: 0, color: currentPlatformMeta.accent }}>
+                {currentPlatformMeta.label}
               </Typography.Title>
               <Typography.Text type="secondary" style={{ fontSize: 12.5 }}>
-                {currentPlatform.description}
+                {currentPlatformMeta.description}
               </Typography.Text>
             </div>
+
+            <div style={{ padding: 14, border: "1px solid #e8edf3", borderRadius: 12, background: "#fff" }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, marginBottom: 12 }}>
+                <div>
+                  <Typography.Text strong>环境状态</Typography.Text>
+                  <Typography.Text type="secondary" style={{ display: "block", fontSize: 12 }}>浏览器与平台登录状态</Typography.Text>
+                </div>
+                <Button
+                  size="small"
+                  icon={currentEnvironment.phase === "checking" ? <LoadingOutlined /> : <CheckCircleOutlined />}
+                  loading={currentEnvironment.phase === "checking"}
+                  disabled={currentStartPending || currentPlatformHasActiveTask}
+                  onClick={() => void handleCheckEnv(platform)}
+                >检查环境</Button>
+              </div>
+
+              {currentEnvironment.phase === "idle" ? (
+                <Typography.Text type="secondary" style={{ fontSize: 12.5 }}>尚未检查。需要确认登录状态时点击右侧按钮，本次结果会保留在当前平台卡片中。</Typography.Text>
+              ) : (
+                <Steps
+                  size="small"
+                  responsive={false}
+                  current={currentEnvironment.phase === "checking" ? currentStepIndex : ENV_STEPS.length - 1}
+                  items={ENV_STEPS.map((step, index) => ({
+                    title: step.title,
+                    status: resolveStepStatus(currentEnvironment.phase, currentEnvironment.result?.status ?? null, index, currentStepIndex),
+                    icon:
+                      currentEnvironment.phase === "checking" && index === currentStepIndex ? <LoadingOutlined />
+                        : currentEnvironment.phase === "done" && index === currentStepIndex && currentEnvironment.result?.status === "login_required" ? <WarningOutlined />
+                          : undefined,
+                  }))}
+                />
+              )}
+              {currentEnvironment.message && <Alert style={{ marginTop: 12 }} type="warning" showIcon message={currentEnvironment.message} />}
+              {currentEnvironment.result?.message && !currentEnvironment.message && (
+                <Typography.Text type="secondary" style={{ display: "block", marginTop: 10, fontSize: 12.5 }}>{currentEnvironment.result.message}</Typography.Text>
+              )}
+              {currentQrSrc && (
+                <div style={{ marginTop: 12, padding: 12, display: "flex", alignItems: "center", gap: 14, background: "#f8fafc", borderRadius: 10 }}>
+                  <Image src={currentQrSrc} width={112} height={112} preview={false} alt={`${currentPlatformMeta.label}登录二维码`} />
+                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>请使用 {currentPlatformMeta.label} App 扫码登录，完成后重新检查环境。</Typography.Text>
+                </div>
+              )}
+            </div>
+
+            <Button
+              block
+              type="primary"
+              size="large"
+              icon={<PlayCircleOutlined />}
+              loading={currentStartPending}
+              disabled={currentStartPending}
+              style={{ background: currentPlatformMeta.accent }}
+              onClick={() => openStartModal(platform)}
+            >
+              {currentStartPending ? "正在加入队列..." : `添加 ${currentPlatformMeta.shortLabel} 任务`}
+            </Button>
           </Space>
         </Card>
 
-        <Card styles={{ body: { padding: 18 } }}>
-          <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-            <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
-              <div>
-                <Typography.Title level={5} style={{ margin: 0 }}>
-                  {currentPlatform.shortLabel} 环境状态
-                </Typography.Title>
-                <Typography.Text type="secondary" style={{ fontSize: 12.5 }}>
-                  确认浏览器驱动与平台登录凭证。
-                </Typography.Text>
-              </div>
-              <Button
-                type="primary"
-                icon={checkPhase === "checking" ? <LoadingOutlined /> : <CheckCircleOutlined />}
-                loading={checkPhase === "checking"}
-                onClick={handleCheckEnv}
-                disabled={taskRunning}
-              >
-                {checkPhase === "checking" ? "检查中..." : `检查${currentPlatform.shortLabel}环境`}
-              </Button>
-            </div>
-
-            {showSteps ? (
-              <Steps
-                size="small"
-                current={
-                  checkPhase === "checking"
-                    ? currentStepIndex
-                    : checkPhase === "done"
-                      ? ENV_STEPS.length - 1
-                      : -1
-                }
-                items={ENV_STEPS.map((step, idx) => ({
-                  title: step.title,
-                  status: resolveStepStatus(
-                    checkPhase,
-                    envResult?.status ?? null,
-                    idx,
-                    currentStepIndex,
-                  ),
-                  icon:
-                    checkPhase === "checking" && idx === currentStepIndex ? (
-                      <LoadingOutlined />
-                    ) : checkPhase === "done" &&
-                      idx === currentStepIndex &&
-                      envResult?.status === "login_required" ? (
-                      <WarningOutlined />
-                    ) : undefined,
-                }))}
-              />
-            ) : (
-              <Alert
-                type="info"
-                showIcon
-                message={`当前选择 ${currentPlatform.label}`}
-                description="准备就绪，点击右侧按钮测试环境联通性。"
-              />
-            )}
-
-            {checkMsg && <Alert type="warning" showIcon message={checkMsg} />}
-
-            {envResult?.message && !checkMsg && showSteps && (
-              <Typography.Text type="secondary" style={{ fontSize: 13 }}>{envResult.message}</Typography.Text>
-            )}
-
-            {qrSrc && (
-              <div
-                style={{
-                  padding: 14,
-                  background: "#f8fafc",
-                  borderRadius: 12,
-                  display: "inline-flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  gap: 8,
-                  border: "1px solid #e2e8f0",
-                }}
-              >
-                <Image
-                  src={qrSrc}
-                  width={180}
-                  height={180}
-                  preview={false}
-                  alt="平台登录二维码"
-                  style={{ borderRadius: 8 }}
-                />
-                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                  {envResult?.message ?? `请使用 ${currentPlatform.label} App 扫码登录`}
-                </Typography.Text>
-              </div>
-            )}
+        <Card styles={{ body: { padding: 18, display: "flex", flexDirection: "column" } }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center", marginBottom: 12, flexWrap: "wrap" }}>
+          <div>
+            <Typography.Title level={5} style={{ margin: 0 }}>任务队列</Typography.Title>
+            <Typography.Text type="secondary" style={{ fontSize: 12.5 }}>
+              最新任务在上 · 运行中 {taskCounts.running} · 排队 {taskCounts.queued}
+            </Typography.Text>
           </div>
+          <Space wrap>
+            <Segmented<QueueFilter>
+              size="small"
+              value={queueFilter}
+              options={[
+                { value: "all", label: "全部" },
+                { value: "boss", label: "BOSS" },
+                { value: "liepin", label: "猎聘" },
+              ]}
+              onChange={setQueueFilter}
+            />
+            <Button
+              size="small"
+              type={selectedTaskId === null ? "primary" : "default"}
+              onClick={() => {
+                setSelectedTaskId(null);
+                setLogCollapsed(false);
+              }}
+            >
+              查看全部日志
+            </Button>
+          </Space>
+        </div>
+
+        {visibleQueueTasks.length === 0 ? (
+          <Alert
+            type="info"
+            showIcon
+            message={queueTasks.length === 0 ? "任务队列为空" : "当前筛选下没有任务"}
+            description={queueTasks.length === 0 ? "从左侧添加任务后，会在这里显示执行状态和顺序。" : "可切换为全部或另一个平台查看任务。"}
+          />
+        ) : (
+          <div
+            style={{
+              display: "grid",
+              gap: 8,
+              maxHeight: 296,
+              overflowY: "auto",
+              paddingRight: 4,
+            }}
+          >
+            {visibleQueueTasks.map((task) => {
+              const selected = selectedTaskId === task.task_id;
+              const queuePosition = task.status === "queued"
+                ? queuedTasksInExecutionOrder.findIndex((candidate) => candidate.task_id === task.task_id) + 1
+                : null;
+              return (
+                <div
+                  key={task.task_id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => {
+                    setSelectedTaskId(task.task_id);
+                    setLogCollapsed(false);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      setSelectedTaskId(task.task_id);
+                      setLogCollapsed(false);
+                    }
+                  }}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "minmax(170px, 1.3fr) minmax(100px, .7fr) auto",
+                    alignItems: "center",
+                    gap: 12,
+                    padding: "11px 12px",
+                    border: `1px solid ${selected ? PLATFORM_META[task.platform].accent : "#e8edf3"}`,
+                    borderRadius: 10,
+                    background: selected ? "rgba(22, 119, 255, 0.04)" : "#fff",
+                    cursor: "pointer",
+                  }}
+                >
+                  <div>
+                    <Space size={6}>
+                      <Tag color={task.platform === "boss" ? "blue" : "purple"}>{PLATFORM_META[task.platform].shortLabel}</Tag>
+                      <Typography.Text strong>{getFlowModeLabel(task.mode)}</Typography.Text>
+                    </Space>
+                    <Typography.Text type="secondary" style={{ display: "block", marginTop: 3, fontSize: 11.5 }}>
+                      {task.task_id.slice(0, 8)} · {new Date(task.created_at).toLocaleString()}
+                    </Typography.Text>
+                  </div>
+                  <Tag color={taskStateColor(task.status)} style={{ width: "fit-content" }}>
+                    {taskStateLabel(task.status)}{queuePosition ? ` · 第 ${queuePosition} 位` : ""}
+                  </Tag>
+                  {isActiveJobTask(task) ? (
+                    <Button
+                      size="small"
+                      danger
+                      loading={task.status === "stopping"}
+                      disabled={task.status === "stopping"}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void handleStopTask(task.task_id);
+                      }}
+                    >停止</Button>
+                  ) : <span />}
+                </div>
+              );
+            })}
+          </div>
+        )}
         </Card>
       </section>
 
-      {/* ── Automation control bar ── */}
-      <Card styles={{ body: { padding: 18 } }}>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            gap: 16,
-            alignItems: "center",
-            flexWrap: "wrap",
-          }}
-        >
-          <div>
-            <Typography.Title level={5} style={{ margin: 0 }}>
-              {currentPlatform.shortLabel} 自动化控制台
-            </Typography.Title>
-            <Typography.Text type="secondary" style={{ fontSize: 13 }}>
-              根据预设筛选条件、简历与回复策略，安全发起求职流。
-            </Typography.Text>
-            {currentPlatform.limitation && (
-              <Typography.Text type="warning" style={{ display: "block", marginTop: 4, fontSize: 12 }}>
-                {currentPlatform.limitation}
-              </Typography.Text>
-            )}
-          </div>
-          <Space wrap>
-            <Button
-              type="primary"
-              danger={taskRunning && !taskStopping}
-              size="large"
-              icon={taskStopping ? <LoadingOutlined /> : taskRunning ? <StopOutlined /> : <PlayCircleOutlined />}
-              loading={taskStopping}
-              disabled={taskStopping}
-              onClick={taskRunning ? () => void handleStopTask() : openStartModal}
-            >
-              {taskStopping ? `${runningPlatformLabel} 任务停止中...` : taskRunning ? `停止 ${runningPlatformLabel} 任务` : `启动 ${currentPlatform.shortLabel} 任务`}
-            </Button>
-            {taskRunning && (
-              <Typography.Text type="warning" style={{ alignSelf: "center", fontWeight: 500 }}>
-                {taskStopping ? `${runningPlatformLabel} 任务正在安全停止...` : `${runningPlatformLabel} 任务运行中...`}
-              </Typography.Text>
-            )}
-          </Space>
-        </div>
-      </Card>
-
       {/* ── Start modal ── */}
       <Modal
-        title={`启动 ${currentPlatform.label} 任务`}
+        title={`添加 ${PLATFORM_META[modalPlatform].label} 任务`}
         open={startModalOpen}
         centered
         width={640}
         styles={{ body: { maxHeight: "60vh", overflowY: "auto", paddingRight: 4 } }}
         onOk={() => void handleStartConfirm()}
-        confirmLoading={preflightLoading}
         onCancel={closeStartModal}
         okText="确认启动"
         cancelText="取消"
         okButtonProps={{
           disabled:
-            taskRunning ||
+            modalTaskStartPending ||
             (selectedMode === "periodic_job_hunting" &&
               (!intervalMinutes || intervalMinutes <= 0)),
         }}
       >
         <Space direction="vertical" size={16} style={{ width: "100%", paddingTop: 8 }}>
-          {readinessLoading ? (
-            // 加载占位，保证弹窗高度不会在预检前后剧烈跳变
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                minHeight: 88,
-                padding: "12px 14px",
-                background: "#f8fafc",
-                border: "1px solid #e2e8f0",
-                borderRadius: 8,
-              }}
-            >
-              <LoadingOutlined style={{ color: "#1677ff" }} />
-              <Typography.Text type="secondary" style={{ fontSize: 13 }}>
-                正在检查运行前置条件…
-              </Typography.Text>
-            </div>
-          ) : readiness ? (
-            <Alert
-              type={readiness.ready ? "success" : "warning"}
-              showIcon
-              message={readiness.ready ? "环境与配置预检通过" : "尚有配置未完善"}
-              description={
-                <Space direction="vertical" size={6} style={{ width: "100%", marginTop: 4 }}>
-                  {readiness.summary.map((line) => <Typography.Text key={line}>{line}</Typography.Text>)}
-                  {/* 默认只展示需要处理的阻塞/警告项 */}
-                  {pendingReadinessItems.map((item) => renderReadinessItem(item))}
-                  {readyReadinessItems.length > 0 ? (
-                    <div>
-                      <Button
-                        type="link"
-                        size="small"
-                        style={{ padding: 0, height: "auto", fontSize: 12 }}
-                        onClick={() => setReadyDetailsOpen((open) => !open)}
-                      >
-                        {readyDetailsOpen
-                          ? "收起已就绪的检查项"
-                          : pendingReadinessItems.length === 0
-                            ? `${readyReadinessItems.length} 项检查全部通过，查看明细`
-                            : `其余 ${readyReadinessItems.length} 项检查已就绪，查看明细`}
-                      </Button>
-                    </div>
-                  ) : null}
-                  {readyDetailsOpen ? readyReadinessItems.map((item) => renderReadinessItem(item)) : null}
-                </Space>
-              }
-            />
-          ) : (
-            <Alert
-              type="info"
-              showIcon
-              message="暂未获取到预检结果"
-              description="可切换运行模式或点击「确认启动」重新检查运行前置条件。"
-            />
-          )}
           <Radio.Group
             value={selectedMode}
             onChange={(event) => setSelectedMode(event.target.value)}
@@ -851,7 +806,7 @@ const WorkspacePage = ({
           >
             <Space direction="vertical" style={{ width: "100%" }} size={12}>
               {FLOW_MODE_OPTIONS.filter(
-                (option) => platform === "boss" || option.key !== "sync_chat_history",
+                (option) => modalPlatform === "boss" || option.key !== "sync_chat_history",
               ).map((option) => (
                 <Card
                   key={option.key}
@@ -906,8 +861,10 @@ const WorkspacePage = ({
             <Typography.Title level={5} style={{ margin: 0 }}>
               运行日志
             </Typography.Title>
-            <Tag color={logFilter === "all" ? "default" : "processing"}>
-              {logFilter === "all" ? "全部平台" : `${PLATFORM_META[logFilter].shortLabel}视图`}
+            <Tag color={selectedTask ? "processing" : "default"}>
+              {selectedTask
+                ? `${PLATFORM_META[selectedTask.platform].shortLabel} · ${selectedTask.task_id.slice(0, 8)}`
+                : "全部任务"}
             </Tag>
           </Space>
           <Space>
@@ -917,12 +874,11 @@ const WorkspacePage = ({
             {!logCollapsed && (
               <>
                 <Button size="small" icon={<CopyOutlined />} onClick={handleCopyLog}>复制</Button>
-                <Segmented<LogFilter>
-                  size="small"
-                  value={logFilter}
-                  options={LOG_FILTER_OPTIONS}
-                  onChange={setLogFilter}
-                />
+                {selectedTaskId && (
+                  <Button size="small" onClick={() => setSelectedTaskId(null)}>
+                    退出任务日志
+                  </Button>
+                )}
               </>
             )}
           </Space>

--- a/src/view/workspace/index.tsx
+++ b/src/view/workspace/index.tsx
@@ -107,7 +107,6 @@ const PLATFORM_META: Record<PlatformKind, PlatformMeta> = {
     shortLabel: "猎聘",
     accent: "#722ed1",
     description: "适合猎聘职位搜索、筛选和主动沟通。",
-    limitation: "猎聘暂不支持自动发送图片资源，图片话术会被跳过。",
   },
 };
 

--- a/src/view/workspace/index.tsx
+++ b/src/view/workspace/index.tsx
@@ -7,6 +7,7 @@ import {
   InputNumber,
   Modal,
   Radio,
+  Select,
   Segmented,
   Space,
   Steps,
@@ -44,6 +45,7 @@ import {
   isActiveJobTask,
 } from "../../types/rpa";
 import type { JobDetail } from "../../types/job-detail";
+import { getDefaultJobProfile, getJobProfiles, type AppRuntimeConfig } from "../../types/app-config";
 
 type CheckPhase = "idle" | "checking" | "done";
 
@@ -159,6 +161,12 @@ export function filterTaskLogContent(
     .join("\n");
 }
 
+export function getTaskProfileLabel(task: Pick<JobTaskInfo, "mode" | "profile_id" | "profile_name">): string {
+  if (task.mode === "reply_unread" && !task.profile_id) return "按会话方案自动路由";
+  if (task.mode === "sync_chat_history" && !task.profile_id) return "不使用求职方案";
+  return task.profile_name || "默认求职方案";
+}
+
 const TASK_STATE_ORDER: Record<JobTaskInfo["status"], number> = {
   running: 0,
   starting: 0,
@@ -239,7 +247,9 @@ interface StatTile {
 /* ────────── Component ────────── */
 
 const WorkspacePage = ({
+  config,
 }: {
+  config: AppRuntimeConfig;
   onNavigate?: (tab: "job-data") => void;
   onOpenConfig?: (group: "resume" | "llm" | "job" | "greet" | "reply" | "browser") => void;
 }) => {
@@ -259,6 +269,7 @@ const WorkspacePage = ({
   const [startModalOpen, setStartModalOpen] = useState(false);
   const [selectedMode, setSelectedMode] = useState<FlowMode>("job_hunting");
   const [intervalMinutes, setIntervalMinutes] = useState<number>(30);
+  const [selectedProfileId, setSelectedProfileId] = useState<string>(() => getDefaultJobProfile(config).id);
   const [platform, setPlatform] = useState<PlatformKind>("boss");
   const [modalPlatform, setModalPlatform] = useState<PlatformKind>("boss");
   const [pendingStartPlatforms, setPendingStartPlatforms] = useState<
@@ -391,6 +402,7 @@ const WorkspacePage = ({
       startedPlatform: PlatformKind,
       mode: FlowMode,
       intervalMinutes?: number,
+      profileId?: string,
     ) => {
       setPendingStartPlatforms((current) => ({
         ...current,
@@ -401,6 +413,7 @@ const WorkspacePage = ({
           platform: startedPlatform,
           mode,
           intervalMinutes: mode === "periodic_job_hunting" ? intervalMinutes : undefined,
+          profileId: mode === "job_hunting" || mode === "periodic_job_hunting" ? profileId : undefined,
         });
         if (!result.success || !result.data) {
           messageApi.error(commandErrorMessage(result.error, "启动失败"));
@@ -428,8 +441,9 @@ const WorkspacePage = ({
   const openStartModal = useCallback((targetPlatform: PlatformKind) => {
     setModalPlatform(targetPlatform);
     setSelectedMode("job_hunting");
+    setSelectedProfileId(getDefaultJobProfile(config).id);
     setStartModalOpen(true);
-  }, []);
+  }, [config]);
 
   const closeStartModal = useCallback(() => {
     setStartModalOpen(false);
@@ -441,6 +455,7 @@ const WorkspacePage = ({
       modalPlatform,
       selectedMode,
       selectedMode === "periodic_job_hunting" ? intervalMinutes : undefined,
+      selectedMode === "job_hunting" || selectedMode === "periodic_job_hunting" ? selectedProfileId : undefined,
     );
   }, [
     closeStartModal,
@@ -448,6 +463,7 @@ const WorkspacePage = ({
     intervalMinutes,
     modalPlatform,
     selectedMode,
+    selectedProfileId,
   ]);
 
   const handleStopTask = useCallback(async (taskId: string) => {
@@ -756,6 +772,9 @@ const WorkspacePage = ({
                     <Typography.Text type="secondary" style={{ display: "block", marginTop: 3, fontSize: 11.5 }}>
                       {task.task_id.slice(0, 8)} · {new Date(task.created_at).toLocaleString()}
                     </Typography.Text>
+                    <Typography.Text type="secondary" style={{ display: "block", marginTop: 2, fontSize: 11.5 }}>
+                      方案：{getTaskProfileLabel(task)}
+                    </Typography.Text>
                   </div>
                   <Tag color={taskStateColor(task.status)} style={{ width: "fit-content" }}>
                     {taskStateLabel(task.status)}{queuePosition ? ` · 第 ${queuePosition} 位` : ""}
@@ -842,6 +861,26 @@ const WorkspacePage = ({
               />
             </div>
           )}
+          {(selectedMode === "job_hunting" || selectedMode === "periodic_job_hunting") ? (
+            <div style={{ padding: "12px", background: "#f0f7ff", border: "1px solid #d6e8ff", borderRadius: 8 }}>
+              <Typography.Text strong style={{ display: "block", marginBottom: 8 }}>本次使用的求职方案</Typography.Text>
+              <Select
+                aria-label="本次使用的求职方案"
+                style={{ width: "100%" }}
+                value={selectedProfileId}
+                onChange={setSelectedProfileId}
+                options={getJobProfiles(config).filter((profile) => !profile.archived).map((profile) => ({
+                  value: profile.id,
+                  label: `${profile.name}${profile.id === (config.default_job_profile_id || getDefaultJobProfile(config).id) ? "（默认）" : ""}`,
+                }))}
+              />
+              <Typography.Text type="secondary" style={{ display: "block", marginTop: 6, fontSize: 12 }}>
+                任务加入队列后会固定使用该方案快照，之后修改配置不会影响本次任务。
+              </Typography.Text>
+            </div>
+          ) : selectedMode === "reply_unread" ? (
+            <Alert type="info" showIcon message="按会话方案自动路由" description="每条未读消息会沿用首次联系该岗位时使用的求职方案。" />
+          ) : null}
         </Space>
       </Modal>
 

--- a/src/view/workspace/workspace.test.tsx
+++ b/src/view/workspace/workspace.test.tsx
@@ -8,6 +8,7 @@ import { invoke } from "@tauri-apps/api/core";
 import {
   filterTaskLogContent,
   filterTasksByPlatform,
+  getTaskProfileLabel,
   requestStopJobTask,
   sortTasksForQueue,
   sortTasksNewestFirst,
@@ -103,5 +104,12 @@ describe("workspace task API", () => {
       "liepin-old",
     ]);
     expect(filterTasksByPlatform(tasks, "all")).toBe(tasks);
+  });
+
+  it("shows conversation routing for reply tasks without a fixed profile", () => {
+    const replyTask = { ...task("reply", "boss", "queued", "2026-08-13T12:00:00Z"), mode: "reply_unread" as const };
+    expect(getTaskProfileLabel(replyTask)).toBe("按会话方案自动路由");
+    expect(getTaskProfileLabel({ ...replyTask, profile_name: "按会话自动选择" })).toBe("按会话方案自动路由");
+    expect(getTaskProfileLabel({ ...replyTask, profile_id: "ai", profile_name: "AI 工程师" })).toBe("AI 工程师");
   });
 });

--- a/src/view/workspace/workspace.test.tsx
+++ b/src/view/workspace/workspace.test.tsx
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import {
+  filterTaskLogContent,
+  filterTasksByPlatform,
+  requestStopJobTask,
+  sortTasksForQueue,
+  sortTasksNewestFirst,
+} from ".";
+import type { JobTaskInfo, JobTaskState, PlatformKind } from "../../types/rpa";
+
+function task(
+  taskId: string,
+  platform: PlatformKind,
+  status: JobTaskState,
+  createdAt: string,
+): JobTaskInfo {
+  return {
+    task_id: taskId,
+    platform,
+    mode: "job_hunting",
+    status,
+    created_at: createdAt,
+    started_at: null,
+    finished_at: null,
+    error: null,
+  };
+}
+
+describe("workspace task API", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("passes the selected task id when stopping a task", async () => {
+    vi.mocked(invoke).mockResolvedValue({ success: true, data: null, error: null });
+
+    await requestStopJobTask("liepin-task-42");
+
+    expect(invoke).toHaveBeenCalledOnce();
+    expect(invoke).toHaveBeenCalledWith("stop_job_task", {
+      taskId: "liepin-task-42",
+    });
+  });
+
+  it("filters logs by the exact selected task id", () => {
+    const content = [
+      "[INFO] [task=boss-1] [BOSS] first",
+      "[INFO] [task=liepin-2] [猎聘] second",
+      "[INFO] legacy line",
+    ].join("\n");
+
+    expect(filterTaskLogContent(content, "liepin-2")).toBe(
+      "[INFO] [task=liepin-2] [猎聘] second",
+    );
+    expect(filterTaskLogContent(content, null)).toBe(content);
+  });
+
+  it("orders running tasks first, queued tasks FIFO, then recent history", () => {
+    const tasks = [
+      task("old-finished", "boss", "succeeded", "2026-08-13T08:00:00Z"),
+      task("queue-two", "boss", "queued", "2026-08-13T10:00:00Z"),
+      task("running", "liepin", "running", "2026-08-13T11:00:00Z"),
+      task("queue-one", "boss", "queued", "2026-08-13T09:00:00Z"),
+      task("new-failed", "liepin", "failed", "2026-08-13T12:00:00Z"),
+    ];
+
+    expect(sortTasksForQueue(tasks).map((item) => item.task_id)).toEqual([
+      "running",
+      "queue-one",
+      "queue-two",
+      "new-failed",
+      "old-finished",
+    ]);
+  });
+
+  it("orders the visible queue newest first", () => {
+    const tasks = [
+      task("old", "boss", "queued", "2026-08-13T08:00:00Z"),
+      task("new", "liepin", "running", "2026-08-13T12:00:00Z"),
+      task("middle", "boss", "failed", "2026-08-13T10:00:00Z"),
+    ];
+
+    expect(sortTasksNewestFirst(tasks).map((item) => item.task_id)).toEqual([
+      "new",
+      "middle",
+      "old",
+    ]);
+  });
+
+  it("filters the queue by platform without changing task order", () => {
+    const tasks = [
+      task("liepin-new", "liepin", "running", "2026-08-13T12:00:00Z"),
+      task("boss-middle", "boss", "queued", "2026-08-13T10:00:00Z"),
+      task("liepin-old", "liepin", "failed", "2026-08-13T08:00:00Z"),
+    ];
+
+    expect(filterTasksByPlatform(tasks, "liepin").map((item) => item.task_id)).toEqual([
+      "liepin-new",
+      "liepin-old",
+    ]);
+    expect(filterTasksByPlatform(tasks, "all")).toBe(tasks);
+  });
+});


### PR DESCRIPTION
## 变更内容
- 猎聘沟通改用 IM 接口取数，支持同意简历请求和自动发送图片资源。
- 登录校验改用用户信息接口，修复加载中状态误判；请求记录器保留 IM 完整响应。
- 支持浏览器自动化任务队列与 BOSS/猎聘双平台并行执行。
- 支持多求职方案、任务快照和路由切换。
- 统一部分 Rust 代码格式。

## 影响
提升猎聘自动沟通稳定性，并支持更灵活的多方案并行求职任务。

## 验证
已执行 git diff --check。